### PR TITLE
Bugfix: Skip running generator for index item deletion

### DIFF
--- a/Model/Generator/Component/Processor/AtomicUpdater.php
+++ b/Model/Generator/Component/Processor/AtomicUpdater.php
@@ -31,14 +31,12 @@ class AtomicUpdater extends Component implements ProcessorInterface
      */
     public function process(array $items)
     {
-        $method = $this->getData('action') . 'DoofinderItems';
-
         $data = array_map(function ($item) {
             return array_filter($item->getData());
         }, $items);
 
         try {
-            $this->_search->{$method}($data);
+            $this->_search->updateDoofinderItems($data);
         } catch (\Exception $e) {
             $this->_logger->debug($e->getMessage());
             throw $e;

--- a/Test/Unit/Model/Generator/Component/Processor/AtomicUpdaterTest.php
+++ b/Test/Unit/Model/Generator/Component/Processor/AtomicUpdaterTest.php
@@ -38,7 +38,7 @@ class AtomicUpdaterTest extends BaseTestCase
 
         $this->_search = $this->getMock(
             '\Doofinder\Feed\Helper\Search',
-            ['someActionDoofinderItems'],
+            [],
             [],
             '',
             false
@@ -50,7 +50,6 @@ class AtomicUpdaterTest extends BaseTestCase
                 'search' => $this->_search,
                 'data' => [
                     'api_key' => 'sample_api_key',
-                    'action' => 'someAction',
                 ],
             ]
         );
@@ -68,7 +67,7 @@ class AtomicUpdaterTest extends BaseTestCase
 
         $this->_item->method('getData')->willReturn($data);
 
-        $this->_search->expects($this->once())->method('someActionDoofinderItems')
+        $this->_search->expects($this->once())->method('updateDoofinderItems')
             ->with([$data]);
 
         $this->_model->process([$this->_item]);

--- a/Test/Unit/Search/IndexerHandlerTest.php
+++ b/Test/Unit/Search/IndexerHandlerTest.php
@@ -98,7 +98,7 @@ class IndexerHandlerTest extends BaseTestCase
         parent::setUp();
 
         // @codingStandardsIgnoreStart
-        $this->_documents = new \ArrayObject([['sample' => 'item']]);
+        $this->_documents = new \ArrayObject([1234 => ['sample' => 'item']]);
         // @codingStandardsIgnoreEnd
 
         $this->_batch = $this->getMock(
@@ -286,9 +286,7 @@ class IndexerHandlerTest extends BaseTestCase
                             ],
                         ],
                         'processors' => [
-                            'AtomicUpdater' => [
-                                'action' => 'update',
-                            ],
+                            'AtomicUpdater' => [],
                             'Mapper' => [
                                 'map' => [],
                             ],
@@ -313,31 +311,11 @@ class IndexerHandlerTest extends BaseTestCase
         $this->_batch->expects($this->at(0))->method('getItems')
             ->with($this->_documents, 100)->willReturn([$batch]);
 
-        $this->_generator->expects($this->once())->method('run');
-
-        $this->_generatorFactory
-            ->expects($this->once())
-            ->method('create')
+        $this->_searchHelper->expects($this->once())
+            ->method('deleteDoofinderItems')
             ->with([
-                'data' => [
-                    'config' => [
-                        'fetchers' => [
-                            'Product\Fixed' => [
-                                'products' => [$this->_product],
-                            ],
-                        ],
-                        'processors' => [
-                            'AtomicUpdater' => [
-                                'action' => 'delete',
-                            ],
-                            'Mapper' => [
-                                'map' => [],
-                            ],
-                        ],
-                    ],
-                ],
-            ])
-            ->willReturn($this->_generator);
+                ['id' => 1234],
+            ]);
 
         $this->_indexerHandler->expects($this->once())->method('deleteIndex')
             ->with([$this->_dimension], $this->createIterator($batch));


### PR DESCRIPTION
In case of product deletion generator tried to fetch non-existing product.

refs #58920

Change-Id: Ib47af2235cdad9c70ff3179475b2febe554ebc6b