### PR TITLE
Add fixes in indexer and search

### DIFF
--- a/Model/Indexer/Data/Map/Update.php
+++ b/Model/Indexer/Data/Map/Update.php
@@ -70,6 +70,9 @@ class Update implements MapInterface
             $fetcher->clear();
         }
 
+        $documents = array_filter($documents, function ($document) {
+            return isset($document['id']);
+        });
         return $documents;
     }
 }

--- a/Search/Filters.php
+++ b/Search/Filters.php
@@ -4,6 +4,7 @@ namespace Doofinder\Feed\Search;
 
 use Doofinder\Feed\Model\Adapter\FieldMapper\FieldResolver\Price as PriceNameResolver;
 use Magento\Framework\Search\RequestInterface;
+use Magento\Framework\Api\SortOrder;
 
 /**
  * Class Filters
@@ -50,11 +51,16 @@ class Filters
             return $filters;
         }
         foreach ($request->getSort() as $sort) {
+            $direction = $sort['direction'];
+            if ($direction instanceof SortOrder) {
+                $direction = $direction->getDirection();
+            }
+
             if ($sort['field'] == 'price') {
-                $filters['sort'][] = [$this->priceNameResolver->getFiledName() => $sort['direction']];
+                $filters['sort'][] = [$this->priceNameResolver->getFiledName() => $direction];
                 continue;
             }
-            $filters['sort'][] = [$sort['field'] => $sort['direction']];
+            $filters['sort'][] = [$sort['field'] => $direction];
         }
 
         return $filters;


### PR DESCRIPTION
Do not try to index products without ID (it's required field in Doofinder)
Check if direction is an object which cannot be converted to string

refs #64846
refs #64797

Change-Id: I010ad6dc58389862b980d9725fe140d7615bf738