### PR TITLE
Continue installation when one website creation fails

### DIFF
--- a/Controller/Adminhtml/Integration/CreateStore.php
+++ b/Controller/Adminhtml/Integration/CreateStore.php
@@ -96,7 +96,6 @@ class CreateStore extends Action implements HttpGetActionInterface
         $success = true;
         foreach($this->storeConfig->getAllWebsites() as $website) {
             try {
-                $this->logger->error($this->storeConfig->getLanguageFromStore($website->getDefaultStore()));
                 $websiteConfig = [
                     "name" => $website->getName(),
                     "platform" => "magento2",
@@ -104,7 +103,6 @@ class CreateStore extends Action implements HttpGetActionInterface
                     "skip_indexation" => false,
                     "search_engines" => $this->generateSearchEngineData((int)$website->getId())
                 ];
-                $this->logger->error(\Zend_Json::encode($websiteConfig));
                 $response = $this->storeConfig->createStore($websiteConfig);
                 $this->saveInstallationConfig((int)$website->getId(), $response["installation_id"], $response["script"]);
             } catch (Exception $e) {

--- a/Controller/Adminhtml/Integration/CreateStore.php
+++ b/Controller/Adminhtml/Integration/CreateStore.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doofinder\Feed\Controller\Adminhtml\Integration;
 
-use Doofinder\Feed\Helper\Indice as IndiceHelper;
 use Doofinder\Feed\Helper\SearchEngine;
 use Doofinder\Feed\Helper\StoreConfig;
 use Exception;
@@ -16,8 +15,6 @@ use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Escaper;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\App\Cache\Frontend\Pool;
-use Magento\Framework\App\Cache\TypeListInterface;
-use Magento\Framework\App\Cache\Type\Config;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\Webapi\Exception as WebapiException;
 use Magento\Integration\Api\IntegrationServiceInterface;
@@ -27,9 +24,6 @@ use Psr\Log\LoggerInterface;
 
 class CreateStore extends Action implements HttpGetActionInterface
 {
-    /** @var SearchEngine */
-    private $searchEngineHelper;
-
     /** @var AttributeCollectionFactory */
     protected $attributeCollectionFactory;
 
@@ -61,7 +55,6 @@ class CreateStore extends Action implements HttpGetActionInterface
     public function __construct(
         WriterInterface $configWriter,
         StoreConfig $storeConfig,
-        SearchEngine $searchEngineHelper,
         JsonFactory $resultJsonFactory,
         Escaper $escaper,
         UrlInterface $urlInterface,
@@ -72,7 +65,6 @@ class CreateStore extends Action implements HttpGetActionInterface
     ) {
         $this->configWriter = $configWriter;
         $this->storeConfig = $storeConfig;
-        $this->searchEngineHelper = $searchEngineHelper;
         $this->resultJsonFactory = $resultJsonFactory;
         $this->escaper = $escaper;
         $this->urlInterface = $urlInterface;
@@ -90,36 +82,43 @@ class CreateStore extends Action implements HttpGetActionInterface
     public function execute()
     {
         $resultJson = $this->resultJsonFactory->create();
-        try {
-            $this->generateDoofinderStores();
+        if ($this->generateDoofinderStores() == true) {
             $resultJson->setData(true);
-        } catch (Exception $e) {
-            $this->logger->error('Initial Setup error: ' . $e->getMessage());
+        } else {
+            $resultJson->setHttpResponseCode(WebapiException::HTTP_INTERNAL_ERROR);
+            $resultJson->setData(false);
         }
-
         return $resultJson;
     }
 
     public function generateDoofinderStores()
     {
+        $success = true;
         foreach($this->storeConfig->getAllWebsites() as $website) {
-            $websiteConfig = [
-                "name" => $website->getName(),
-                "platform" => "magento2",
-                "primary_language" => $this->storeConfig->getLanguageFromStore($website->getDefaultStore()),
-                "skip_indexation" => false,
-                "search_engines" => $this->generateSearchEngineData((int)$website->getId())
-            ];
-
-            $response = $this->storeConfig->createStore($websiteConfig);
-            $this->saveInstallationConfig((int)$website->getId(), $response["installation_id"], $response["script"]);
+            try {
+                $this->logger->error($this->storeConfig->getLanguageFromStore($website->getDefaultStore()));
+                $websiteConfig = [
+                    "name" => $website->getName(),
+                    "platform" => "magento2",
+                    "primary_language" => $this->storeConfig->getLanguageFromStore($website->getDefaultStore()),
+                    "skip_indexation" => false,
+                    "search_engines" => $this->generateSearchEngineData((int)$website->getId())
+                ];
+                $this->logger->error(\Zend_Json::encode($websiteConfig));
+                $response = $this->storeConfig->createStore($websiteConfig);
+                $this->saveInstallationConfig((int)$website->getId(), $response["installation_id"], $response["script"]);
+            } catch (Exception $e) {
+                $success = false;
+                $this->logger->error('Error creating store for website "' . $website->getName() . '". ' . $e->getMessage());
+            }
         }
+        return $success;
     }
 
     public function generateSearchEngineData($websiteID)
     {
         $searchEngineConfig = [];
-        foreach ($this->storeConfig->getAllStores() as $store) {
+        foreach ($this->storeConfig->getWebsiteStores($websiteID) as $store) {
             $integrationToken = $this->integrationService
                 ->get($this->storeConfig->getIntegrationId())
                 ->getData(Tokens::DATA_TOKEN);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.5.5">
+    <module name="Doofinder_Feed" setup_version="0.5.6">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/view/adminhtml/web/js/link-account.js
+++ b/view/adminhtml/web/js/link-account.js
@@ -118,12 +118,10 @@ define([
 
     function ajaxRequestFail(jqXHR, status, error) {
         $('body').trigger('processStop');
-        let failStep = jqXHR.responseText;
         alert({
             content: $.mage.__(
-              'Installation has failed in step "' + failStep + '". ' +
-              'Please, uninstall and install again the extension following documentation instructions. ' +
-              'After installation is complete run again this Initial Setup.'
+              'Installation has failed. Please take a look into the logs for more information.' +
+              'Maybe you need uninstall and install again the extension following documentation instructions. '
             )
         });
         window.console && console.log(status + ': ' + error + '\nResponse text:\n' + jqXHR.responseText);


### PR DESCRIPTION
- Avoid installation fail when one of the store view contains an unsopported language. Right now the Website that contains the wrong store view won't be created but will continue with the rest of websites.
- Fixed error that includes all magento stores when creating a store in doofinder.