### PR TITLE
Fix compatibility php 7.1

### DIFF
--- a/Api/Data/ChangedProductInterface.php
+++ b/Api/Data/ChangedProductInterface.php
@@ -58,21 +58,6 @@ interface ChangedProductInterface
     const OPERATION_TYPE_CREATE = 'create';
 
     /**
-     * Appointment id
-     *
-     * @return int|null
-     */
-    public function getId();
-
-    /**
-     * Set trace id
-     *
-     * @param int $id
-     * @return $this
-     */
-    public function setId(int $id);
-
-    /**
      * Get product id
      *
      * @return int|null

--- a/Model/Generator/Map/Product/Grouped.php
+++ b/Model/Generator/Map/Product/Grouped.php
@@ -14,7 +14,7 @@ class Grouped extends ProductMap
      * @param string $field
      * @return float|null
      */
-    public function getProductPrice(Product $product, $field): ?float
+    public function getProductPrice(Product $product, string $field): ?float
     {
         if ($field == 'final_price') {
             // Magento will return final price properly

--- a/Wrapper/Throttle.php
+++ b/Wrapper/Throttle.php
@@ -25,7 +25,7 @@ class Throttle
     /**
      * @param object $obj
      */
-    public function __construct(object $obj)
+    public function __construct($obj)
     {
         $this->obj = $obj;
     }


### PR DESCRIPTION
Seems that we had some issues with PHP version 7.1. Was due to version 7.1 is strongly type than latest version and was crashing the compilation.
I had to change 3 things:
- Interface had two functions definitions that wasn't implemented in the class
![image](https://user-images.githubusercontent.com/92720455/181816518-b2c5da98-d03a-449e-b9bd-5436e9f4efb0.png)

- One parameter type that has to match with the type defined in the class Model/Generator/Map/Product.php
![image](https://user-images.githubusercontent.com/92720455/181811108-ccae9054-03cb-4fa7-adfb-e12372c6aae4.png)

- This version of PHP doesn't support object as a type so I removed the type 
![image](https://user-images.githubusercontent.com/92720455/181810001-ddb8c9a7-c885-43bb-8c8a-d206aa609251.png)

I've tested those changes with PHP version 7.1 and 7.4 and the plugin is working correctly.