### PR TITLE
Removed function response type to avoid m2.3 errors

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -496,9 +496,8 @@ class Product extends AbstractHelper
      *
      * @param ProductModel $product
      * @param string $attributeCode
-     * @return string|null
      */
-    public function getAttributeText(ProductModel $product, string $attributeCode): ?string
+    public function getAttributeText(ProductModel $product, string $attributeCode)
     {
         return $this->getAttribute($product, $attributeCode);
     }

--- a/Model/Generator/Map/Product.php
+++ b/Model/Generator/Map/Product.php
@@ -381,9 +381,8 @@ class Product implements MapInterface
      * @param ProductModel $product
      * @param string $attributeCode
      *
-     * @return string|null
      */
-    public function getAttributeText(ProductModel $product, string $attributeCode): ?string
+    public function getAttributeText(ProductModel $product, string $attributeCode)
     {
         return $this->productHelper->getAttributeText($product, $attributeCode);
     }

--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -6,7 +6,6 @@ namespace Doofinder\Feed\Model;
 
 use Magento\Catalog\Api\Data\ProductExtension;
 use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Api\Data\ProductSearchResultsInterface;
 use Magento\Catalog\Api\Data\ProductSearchResultsInterfaceFactory;
 use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
 use Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper;
@@ -212,7 +211,7 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
     /**
      * @inheritDoc
      */
-    public function getList(SearchCriteriaInterface $searchCriteria): ProductSearchResultsInterface
+    public function getList(SearchCriteriaInterface $searchCriteria)
     {
         $searchResult = parent::getList($searchCriteria);
         $storeId = null;


### PR DESCRIPTION
We are having the following error in magento 2.3 when requesting the info to the custom API:

```
Fatal Error: 'Uncaught TypeError: Return value of Doofinder\\Feed\\Model\\ProductRepository::getList() must be an instance of Magento\\Catalog\\Api\\Data\\ProductSearchResultsInterface, instance of Magento\\Framework\\Api\\SearchResults returned in /home/cloudpanel/htdocs/www.lampwise.co.uk/vendor/doofinder/doofinder-magento2/Model/ProductRepository.php:232\nStack trace:\n#0 /home/cloudpanel/htdocs/www.lampwise.co.uk/generated/code/Doofinder/Feed/Model/ProductRepository/Interceptor.php(37): Doofinder\\Feed\\Model\\ProductRepository->getList(Object(Magento\\Framework\\Api\\SearchCriteria))\n#1 [internal function]: Doofinder\\Feed\\Model\\ProductRepository\\Interceptor->getList(Object(Magento\\Framework\\Api\\SearchCriteria))\n#2 /home/cloudpanel/htdocs/www.lampwise.co.uk/vendor/magento/module-webapi/Controller/Rest/SynchronousRequestProcessor.php(95): call_user_func_array(Array, Array)\n#3 /home/cloudpanel/htdocs/www.lampwise.co.uk/vendor/magento/module-webapi/Controller/Rest.php(188): Magento\\Webapi\\Controller\\Rest\\SynchronousRequestProcessor->proces' in '/home/cloudpanel/htdocs/www.lampwise.co.uk/vendor/doofinder/doofinder-magento2/Model/ProductRepository.php' on line 232
```


Seems that the getList native function return a diferent type for magento 2.3 than 2.4:
![error_magento_type_2](https://user-images.githubusercontent.com/92720455/184932392-c7980ebb-8f34-46ed-b319-add6270ace28.png)
![error_magento_type](https://user-images.githubusercontent.com/92720455/184932397-f731b0ef-543c-4133-9a14-b7d3c3b0c342.png)

To avoid type errors I've removed the type specification in the function.
