### PR TITLE
Fix update on save bug

### DIFF
--- a/Observer/AbstractChangedProductObserver.php
+++ b/Observer/AbstractChangedProductObserver.php
@@ -103,18 +103,6 @@ abstract class AbstractChangedProductObserver implements ObserverInterface
         if (!$this->checkChangedProductExists($changedProduct)) {
             $this->changedProductRepository->save($changedProduct);
         }
-        try {
-            $this->changedProductRepository->save($changedProduct);
-        } catch (AlreadyExistsException $e) {
-            $this->logger->debug(
-                sprintf(
-                    'Product %s (ID: %s) %s change has been already registered.',
-                    $product->getSku(),
-                    $product->getId(),
-                    $this->getOperationType()
-                )
-            );
-        }
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.7.2">
+    <module name="Doofinder_Feed" setup_version="0.7.3">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
This bug caused that the clients with update on save activated couldn't save the same product more than once if the scheduled job hadn't run. This problem was caused by the product trying to be saved on the table more than once, while being unique the combination of operation and product_id.

Ticket: https://doofinder.freshdesk.com/a/tickets/80435 