### PR TITLE
Calculate regular price for grouped products

### DIFF
--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -39,7 +39,6 @@ use Magento\Store\Model\StoreManagerInterface;
 use Doofinder\Feed\Helper\ProductFactory as ProductHelperFactory;
 use Doofinder\Feed\Helper\InventoryFactory as InventoryHelperFactory;
 use Doofinder\Feed\Helper\StoreConfig;
-use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.8.3">
+    <module name="Doofinder_Feed" setup_version="0.8.4">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
For some reason magento2 calculate correctly the regular price for configurable products (taking the minor price of its childs) however for grouped products is returning always 0€, so we've to calculate it manually.

Ticket related: https://doofinder.freshdesk.com/a/tickets/86127