### PR TITLE
Fix amount price calculation when price object is null

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -380,6 +380,10 @@ class Product extends AbstractHelper
             $price = $product->getPriceInfo()->getPrice($type);
         }
 
+        if(!$price){
+            return 0;
+        }
+
         $amount = $price->getAmount();
         if ($tax === null) {
             $tax = $this->taxConfig->getPriceDisplayType() != TaxConfig::DISPLAY_TYPE_EXCLUDING_TAX;

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.8.4">
+    <module name="Doofinder_Feed" setup_version="0.8.5">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Fixes an error when calculating the price when a "grouped" type product does not have any associated product. Return price 0.

(Related ticket: https://doofinder.freshdesk.com/a/tickets/86127)

>  [2022-11-09T04:20:07.445701+00:00] main.CRITICAL: Error: Call to a
> member function getAmount() on null in
> /vendor/doofinder/doofinder-magento2/Helper/Product.php:383
> Stack trace:
> #0
> /vendor/doofinder/doofinder-magento2/Model/ProductRepository.php(380):
> Doofinder\Feed\Helper\Product->getProductPrice()
> #1
> /vendor/doofinder/doofinder-magento2/Model/ProductRepository.php(235):
> Doofinder\Feed\Model\ProductRepository->setExtensionAttributes()
> #2 [internal function]:
> Doofinder\Feed\Model\ProductRepository->getList()
> #3
> /vendor/magento/module-webapi/Controller/Rest/SynchronousRequestProcessor.php(95):
> call_user_func_array()
> #4 /vendor/magento/module-webapi/Controller/Rest.php(188):
> Magento\Webapi\Controller\Rest\SynchronousRequestProcessor->process()
> #5 /vendor/magento/framework/Interception/Interceptor.php(58):
> Magento\Webapi\Controller\Rest->dispatch()
> #6 /vendor/magento/framework/Interception/Interceptor.php(138):
> Magento\Webapi\Controller\Rest\Interceptor->___callParent()
> #7 /vendor/magento/framework/Interception/Interceptor.php(153):
> Magento\Webapi\Controller\Rest\Interceptor->Magento\Framework\Interception\{closure}()
> #8 /generated/code/Magento/Webapi/Controller/Rest/Interceptor.php(23):
> Magento\Webapi\Controller\Rest\Interceptor->___callPlugins()
> #9 /vendor/magento/framework/App/Http.php(116):
> Magento\Webapi\Controller\Rest\Interceptor->dispatch()
> #10 /vendor/magento/framework/App/Bootstrap.php(264):
> Magento\Framework\App\Http->launch()
> #11 /pub/index.php(30): Magento\Framework\App\Bootstrap->run()
> #12 {main} [] [] 