### PR TITLE
Fix special price issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.8.5",
+    "version": "0.8.6",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.8.5">
+    <module name="Doofinder_Feed" setup_version="0.8.6">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
This PR resolves an error that occurs when the special_price and the retail_price or base price are the same.
Being the same, the special_price field is not added to extension_attributes.
On the other hand, Magento detects the special_price and returns it within the custom_attributes, regardless of whether to apply taxes. This causes doofeeds, trying to access the special_price and not finding it, to look in the custom_attributes and return the value without taxes.
![image](https://user-images.githubusercontent.com/1659534/201944775-e5ef1e7f-a947-4453-885d-71c59ac8fd85.png)

To solve this problem, a function has been added to eliminate the custom_attributes related to the special_price.

Related ticket: [#82450](https://doofinder.freshdesk.com/a/tickets/82450)