### PR TITLE
Solve issue missing special_price

### DIFF
--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -212,8 +212,8 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
             }
             $product->load($productId);
             $this->appEmulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
-            $this->setCustomAttributes($product);
             $this->setExtensionAttributes($product, $storeId);
+            $this->setCustomAttributes($product);
             $this->appEmulation->stopEnvironmentEmulation();
             // End Custom code here
             $this->cacheProduct($cacheKey, $product);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.8.8",
+    "version": "0.8.9",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.8.8">
+    <module name="Doofinder_Feed" setup_version="0.8.9">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Seems that in version 0.8.6 (https://github.com/doofinder/doofinder-magento2/pull/237) when we fix the bug with special_price and old magento2 version we introduce a new bug.

We're deleting the special_price from custom attributes before set the extension attributes, so the special_price is never set, we've to change the order to set it correctly:

![image](https://user-images.githubusercontent.com/92720455/207123657-574b9337-13e6-447c-9452-00d5d7195cb0.png)

![image](https://user-images.githubusercontent.com/92720455/207124257-b0feea3a-a56b-406e-bea9-04b091016346.png)
