### PR TITLE
Change store url for admin url

### DIFF
--- a/Block/Adminhtml/Setup.php
+++ b/Block/Adminhtml/Setup.php
@@ -12,7 +12,7 @@ use Magento\Integration\Api\IntegrationServiceInterface;
 use Magento\Integration\Model\Integration;
 use Magento\Integration\Model\ResourceModel\Integration\Collection as IntegrationCollection;
 use Magento\Integration\Model\ResourceModel\Integration\CollectionFactory as IntegrationCollectionFactory;
-use Magento\Store\Model\StoreManagerInterface;
+use Magento\Backend\Helper\Data;
 
 class Setup extends Template
 {
@@ -32,9 +32,9 @@ class Setup extends Template
     private $encryptor;
 
     /**
-     * @var StoreManagerInterface
+     * @var Data
      */
-    private $storeManager;
+    private $backendHelper;
 
     /**
      * @var IntegrationServiceInterface
@@ -48,7 +48,7 @@ class Setup extends Template
      * @param IntegrationCollectionFactory $collectionFactory
      * @param StoreConfig $storeConfig
      * @param EncryptorInterface $encryptor
-     * @param StoreManagerInterface $storeManager
+     * @param Data $backendHelper
      * @param IntegrationServiceInterface $integrationService
      */
     public function __construct(
@@ -56,13 +56,13 @@ class Setup extends Template
         IntegrationCollectionFactory $collectionFactory,
         StoreConfig $storeConfig,
         EncryptorInterface $encryptor,
-        StoreManagerInterface $storeManager,
+        Data $backendHelper,
         IntegrationServiceInterface $integrationService
     ) {
         $this->storeConfig = $storeConfig;
         $this->collectionFactory = $collectionFactory;
         $this->encryptor = $encryptor;
-        $this->storeManager = $storeManager;
+        $this->backendHelper = $backendHelper;
         $this->integrationService = $integrationService;
         parent::__construct($context, []);
     }
@@ -80,7 +80,7 @@ class Setup extends Template
 
         return 'email=' . $this->storeConfig->getEmailAdmin()
             . '&token=' . $token
-            . '&shop_url=' . urlencode($this->storeManager->getStore()->getBaseUrl());
+            . '&shop_url=' . urlencode($this->backendHelper->getUrl());
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.8.9",
+    "version": "0.8.10",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.8.9">
+    <module name="Doofinder_Feed" setup_version="0.8.10">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
When the user makes the doofinder login / signup we generate a callback url (magento store url) to make the postMessage after the login / signup is completed.

Some customers have a different URL for store than for backend, and we're having issues with the shop_url generated by us. This PR change the way in which this URL is generated to solve this issue.