### PR TITLE
Send the full language code while creating the store

### DIFF
--- a/Helper/StoreConfig.php
+++ b/Helper/StoreConfig.php
@@ -235,10 +235,10 @@ class StoreConfig extends AbstractHelper
         parent::__construct($context);
     }
 
-    public function createStore(array $storeData): array 
+    public function createStore(array $storeData): array
     {
         $managementClient = $this->managementClientFactory->create(['apiType' => 'admin']);
-        
+
         return $managementClient->createStore($storeData);
     }
 
@@ -418,7 +418,7 @@ class StoreConfig extends AbstractHelper
                 return $store->isActive();
             }
         );
-    } 
+    }
 
     /**
      * Get API key.
@@ -531,9 +531,7 @@ class StoreConfig extends AbstractHelper
      */
     public function getLanguageFromStore(StoreInterface $store): string
     {
-        $localeCode = explode('_', $this->getStoreLocaleCode($store));
-
-        return $localeCode[0];
+        return str_replace("_", "-", $this->getStoreLocaleCode($store));
     }
 
     /**
@@ -833,7 +831,7 @@ class StoreConfig extends AbstractHelper
         if ($id === null) {
             list($scope, $id) = $this->getCurrentScope();
         }
-        
+
         $custom_attributes = $this->scopeConfig->getValue(self::CUSTOM_ATTRIBUTES, $scope, $id);
         $custom_attributes = ($custom_attributes) ? \Zend_Json::decode($custom_attributes) : null;
         $saved = [];
@@ -893,36 +891,36 @@ class StoreConfig extends AbstractHelper
     }
 
     /**
-     * Function to include the locale and the currency into the script. 
+     * Function to include the locale and the currency into the script.
      * The following entries are covered:
      *    const dfLayerOptions = {
      *      installationId: '4aa94cbd-e2a0-44db-b1d2-f0817ad2a97d',
      *      zone: 'eu1',
      *      currency: 'USD',
-     *      language: 'fr'
+     *      language: 'fr-FR'
      *    };
-     * 
+     *
      *    const dfLayerOptions = {
      *      installationId: '4aa94cbd-e2a0-44db-b1d2-f0817ad2a97d',
      *      zone: 'eu1',
      *      //currency: 'USD',
-     *      //language: 'fr'
+     *      //language: 'fr-FR'
      *    };
-     * 
+     *
      *    const dfLayerOptions = {
      *      installationId: '4aa94cbd-e2a0-44db-b1d2-f0817ad2a97d',
      *      zone: 'eu1'
      *    };
-     * 
+     *
      * @return string
      *    const dfLayerOptions = {
      *      installationId: '4aa94cbd-e2a0-44db-b1d2-f0817ad2a97d',
      *      zone: 'eu1',
      *      currency: 'USD',
-     *      language: 'fr'
+     *      language: 'fr-FR'
      *    };
      */
-    public function include_locale_and_currency($liveLayerScript, $locale, $currency): string 
+    public function include_locale_and_currency($liveLayerScript, $locale, $currency): string
     {
         if (strpos($liveLayerScript, 'language:') !== false){
             $liveLayerScript = preg_replace("/(\/\/\s*)?(language:)(.*?)(\n|,)/m", "$2 '$locale'$4", $liveLayerScript);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.8.11">
+    <module name="Doofinder_Feed" setup_version="0.8.12">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Now we send the full locale "en-US" instead of the lang code "en".

And this is the installation config:
```
{"trigger": "#search", "defaults": {"hashid": "bba89b8e18b5436c909e1b297c3d09a7", "currency": "USD", "language": "en-US"}, "url_hash": true, "search_engines": {"en-US": {"USD": "bba89b8e18b5436c909e1b297c3d09a7"}, "es-ES": {"USD": "331530132a5dd048eb6f0c3646257e52"}, "fr-BE": {"USD": "cc54c0d33c44d89268a2d166babc8ab7"}, "fr-FR": {"USD": "fa7884b267b2e8e0b5480804a50aaaa8"}}}
```
![image](https://user-images.githubusercontent.com/1659534/207634134-65f0de6e-561b-4404-8916-fec909b083e2.png)

