### PR TITLE
Add Store options in store creation payload

### DIFF
--- a/Controller/Adminhtml/Integration/CreateStore.php
+++ b/Controller/Adminhtml/Integration/CreateStore.php
@@ -27,7 +27,7 @@ class CreateStore extends Action implements HttpGetActionInterface
 
     /** @var AttributeCollectionFactory */
     protected $attributeCollectionFactory;
-    
+
     /** @var StoreConfig */
     private $storeConfig;
 
@@ -138,18 +138,18 @@ class CreateStore extends Action implements HttpGetActionInterface
                 "language" => $language,
                 "currency" => $currency,
                 "site_url" => $store->getBaseUrl(),
+                "options" => [
+                    'url' => $this->urlInterface->getBaseUrl() . 'rest/' . $store->getCode() . '/V1/',
+                    'token' => $integrationToken,
+                    'website_id' => $store->getWebsiteId(),
+                ],
                 "datatypes" => [
                     [
                         "name" => "product",
                         "preset" => "product",
                         'datasources' => [
                             [
-                                'type' => 'magento2',
-                                'options' => [
-                                    'url' => $this->urlInterface->getBaseUrl() . 'rest/' . $store->getCode() . '/V1/',
-                                    'token' => $integrationToken,
-                                    'website_id' => $store->getWebsiteId(),
-                                ]
+                                'type' => 'magento2'
                             ]
                         ]
                     ]
@@ -164,7 +164,7 @@ class CreateStore extends Action implements HttpGetActionInterface
     /**
      * Function to store into the data base the installation id as well as the layer script
      */
-    private function saveInstallationConfig($websiteID, $installationId, $script) 
+    private function saveInstallationConfig($websiteID, $installationId, $script)
     {
         $this->storeConfig->setInstallation($installationId, $websiteID);
         $this->storeConfig->setDisplayLayer($script, $websiteID);
@@ -210,8 +210,8 @@ class CreateStore extends Action implements HttpGetActionInterface
         $attributes     = [];
         foreach ($attributeCollection as $attribute) {
             $attribute_id = $attribute->getAttributeId();
-            $attributes[$attribute_id] = ['label' => $this->escaper->escapeHtml($attribute->getFrontendLabel()), 
-                                          'code' => $attribute->getAttributeCode(), 
+            $attributes[$attribute_id] = ['label' => $this->escaper->escapeHtml($attribute->getFrontendLabel()),
+                                          'code' => $attribute->getAttributeCode(),
                                           'enabled' => 'on'];
         }
 

--- a/Controller/Adminhtml/Integration/CreateStore.php
+++ b/Controller/Adminhtml/Integration/CreateStore.php
@@ -95,7 +95,7 @@ class CreateStore extends Action implements HttpGetActionInterface
     public function generateDoofinderStores()
     {
         $success = true;
-        foreach($this->storeConfig->getAllWebsites() as $website) {
+        foreach ($this->storeConfig->getAllWebsites() as $website) {
             try {
                 $searchEngineData = $this->generateSearchEngineData((int)$website->getId());
                 $websiteConfig = [
@@ -139,7 +139,6 @@ class CreateStore extends Action implements HttpGetActionInterface
                 "currency" => $currency,
                 "site_url" => $store->getBaseUrl(),
                 "options" => [
-                    'url' => $this->urlInterface->getBaseUrl() . 'rest/' . $store->getCode() . '/V1/',
                     'token' => $integrationToken,
                     'website_id' => $store->getWebsiteId(),
                 ],
@@ -149,7 +148,10 @@ class CreateStore extends Action implements HttpGetActionInterface
                         "preset" => "product",
                         'datasources' => [
                             [
-                                'type' => 'magento2'
+                                'type' => 'magento2',
+                                'options' => [
+                                    'url' => $this->urlInterface->getBaseUrl() . 'rest/' . $store->getCode() . '/V1/'
+                                ]
                             ]
                         ]
                     ]
@@ -194,7 +196,8 @@ class CreateStore extends Action implements HttpGetActionInterface
      * Function to store the status of the SE indexation.
      * By default we set this value to "STARTED" and will be updated when we receive the callback from doofinder
      */
-    private function setIndexationStatus($storeId) {
+    private function setIndexationStatus($storeId)
+    {
         $status = ["status" => Indexation::DOOFINDER_INDEX_PROCESS_STATUS_STARTED];
         $this->storeConfig->setIndexationStatus($status, $storeId);
     }
@@ -205,14 +208,16 @@ class CreateStore extends Action implements HttpGetActionInterface
     private function setCustomAttributes()
     {
         $attributeCollection = $this->attributeCollectionFactory->create();
-        $attributeCollection->addFieldToFilter('is_user_defined',['eq' => 1]);
-        $attributeCollection->addFieldToFilter('attribute_code',['in' => self::CUSTOM_ATTRIBUTES_ENABLED_DEFAULT]);
+        $attributeCollection->addFieldToFilter('is_user_defined', ['eq' => 1]);
+        $attributeCollection->addFieldToFilter('attribute_code', ['in' => self::CUSTOM_ATTRIBUTES_ENABLED_DEFAULT]);
         $attributes     = [];
         foreach ($attributeCollection as $attribute) {
             $attribute_id = $attribute->getAttributeId();
-            $attributes[$attribute_id] = ['label' => $this->escaper->escapeHtml($attribute->getFrontendLabel()),
-                                          'code' => $attribute->getAttributeCode(),
-                                          'enabled' => 'on'];
+            $attributes[$attribute_id] = [
+                'label' => $this->escaper->escapeHtml($attribute->getFrontendLabel()),
+                'code' => $attribute->getAttributeCode(),
+                'enabled' => 'on'
+            ];
         }
 
         $customAttributes = \Zend_Json::encode($attributes);
@@ -238,6 +243,6 @@ class CreateStore extends Action implements HttpGetActionInterface
      */
     private function getProcessCallbackUrl(StoreInterface $store): string
     {
-        return $store->getBaseUrl() . 'doofinderfeed/setup/processCallback?storeId='.$store->getId();
+        return $store->getBaseUrl() . 'doofinderfeed/setup/processCallback?storeId=' . $store->getId();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.8.14",
+    "version": "0.8.15",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.8.12",
+    "version": "0.8.14",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.8.14">
+    <module name="Doofinder_Feed" setup_version="0.8.15">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.8.12">
+    <module name="Doofinder_Feed" setup_version="0.8.14">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Now we send the options in the Store instead of sending them in the DataSource.

Notice: 
To be merged after https://github.com/doofinder/doomanager/pull/2832