### PR TITLE
Hide field image_size in Magento

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -131,9 +131,9 @@
                        translate="label"
                        type="text"
                        sortOrder="400"
-                       showInDefault="1"
-                       showInWebsite="1"
-                       showInStore="1">
+                       showInDefault="0"
+                       showInWebsite="0"
+                       showInStore="0">
                     <label>Image size</label>
                     <comment>
                         <![CDATA[Export product image with given width. Leave empty to use original size.]]>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.10.4">
+    <module name="Doofinder_Feed" setup_version="0.10.5">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
For now, we've hidden the "image size" field to the client. In the coming update, we'll either remove the remaining logic or adapt it to our processes.

Required by: https://github.com/doofinder/support/issues/798