### PR TITLE
Pedro/763 fix magento GitHub actions

### DIFF
--- a/.github/workflows/scripts/magento-release.php
+++ b/.github/workflows/scripts/magento-release.php
@@ -7,8 +7,8 @@
 class MagentoReleaseClient
 {
     const API_PATH = 'https://developer-api.magento.com/rest/v1';
-    const MAX_RETRIES = 5;
-    const RETRY_AFTER = 20;
+    const MAX_RETRIES = 3;
+    const RETRY_AFTER = 30;
     private $version;
     private $release_notes;
     private $ust;

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.11.0">
+    <module name="Doofinder_Feed" setup_version="0.11.1">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
The MagentoReleaseClient has been modified to retry the release creation when it fails due to the malware analysis of the Magento API not being completed.