### PR TITLE
UNPLUGGED-583 | Added a manual button to execute the process to update the products

### DIFF
--- a/Block/System/Config/UpdateOnClick.php
+++ b/Block/System/Config/UpdateOnClick.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Doofinder\Feed\Block\System\Config;
+
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Backend\Block\Template\Context;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+
+class UpdateOnClick extends Field
+{
+    protected $_template = 'Doofinder_Feed::System/Config/updateOnClickButton.phtml';
+    public function __construct(Context $context, array $data = [])
+    {
+        parent::__construct($context, $data);
+    }
+
+    public function render(AbstractElement $element)
+    {
+        $element->unsScope()->unsCanUseWebsiteValue()->unsCanUseDefaultValue();
+        return parent::render($element);
+    }
+
+    public function updateOnClick()
+    {
+        return $this->getUrl('doofinderfeed/integration/updateOnClick');
+    }
+
+    public function getButtonHtml()
+    {
+        $button = $this->getLayout()->createBlock('Magento\Backend\Block\Widget\Button')->setData([
+            'id' => 'manual-indexing', 'label' => __('Manual indexing'),
+        ]);
+        return $button->toHtml();
+    }
+
+    protected function _getElementHtml(AbstractElement $element)
+    {
+        return $this->_toHtml();
+    }
+}

--- a/Controller/Adminhtml/Integration/UpdateOnClick.php
+++ b/Controller/Adminhtml/Integration/UpdateOnClick.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doofinder\Feed\Controller\Adminhtml\Integration;
+
+use Doofinder\Feed\Cron\Processor;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+
+class UpdateOnClick extends Action
+{
+    private $processor;
+
+    public function __construct(
+        Processor $processor,
+        Context $context
+    ) {
+        $this->processor = $processor;
+        parent::__construct($context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute()
+    {
+        $this->processor->execute();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -153,6 +153,19 @@
                     </comment>
                 </field>
             </group>
+             <group id="doofinder_update_on_click"
+                   translate="label"
+                   type="text"
+                   sortOrder="400"
+                   showInDefault="1"
+                   showInWebsite="0"
+                   showInStore="0">
+                <label>Manual indexing (advanced)</label>
+                <field id="update_on_click" translate="label" type="button" sortOrder="400" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Launch manual indexing</label>
+                    <frontend_model>Doofinder\Feed\Block\System\Config\UpdateOnClick</frontend_model>
+                </field>
+            </group>
             <group id="doofinder_custom_attributes"
                    translate="label"
                    type="text"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.13.0">
+    <module name="Doofinder_Feed" setup_version="0.13.1">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/view/adminhtml/templates/System/Config/updateOnClickButton.phtml
+++ b/view/adminhtml/templates/System/Config/updateOnClickButton.phtml
@@ -1,0 +1,19 @@
+<script>
+    require([
+        'jquery',
+        'mage/translate'
+    ], function($, _t){
+        $('#manual-indexing').click(_ => {
+            if (confirm(_t("This action will update directly the products waiting to be updated in Doofinder. Do you want to proceed?"))) {
+                new Ajax.Request('<?php echo $block->updateOnClick(); ?>', {
+                    loaderArea:     true,
+                    asynchronous:   true,
+                });
+            }
+        });
+    });
+</script>
+
+<?php
+    echo $block->getButtonHtml();
+?>


### PR DESCRIPTION
Required by: https://github.com/doofinder/dfcommon/issues/583.

There is an option to automatically update the products using a cron process that triggers the process at least each 5 minutes. In order not to have to wait until the cron executes it again, this PR adds a button in the plugin config area to automatically trigger it whenever we need the reindexing.

![image](https://github.com/doofinder/doofinder-magento2/assets/128705267/b4db682e-f6ff-4250-8dc5-1006435ce36d)
![image](https://github.com/doofinder/doofinder-magento2/assets/128705267/e63add64-a1f1-4692-a60e-8836a98d7933)
