### PR TITLE
Solve CategoryLink Object error

### DIFF
--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -370,7 +370,11 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
     {
         $categoryIds = [];
         foreach ($categories as $category) {
-            $categoryIds[$category['category_id']] = true;
+            if(is_array($category)){
+                $categoryIds[$category['category_id']] = true;
+            } else {
+                $categoryIds[$category->getCategoryId()] = true;
+            }
         }
         
         // Load paths of product categories to load their parents

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.13.4",
+    "version": "0.13.5",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.13.4">
+    <module name="Doofinder_Feed" setup_version="0.13.5">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Fix Uncaught Error: `Cannot use object of type Magento\Catalog\Model\CategoryLink as array`

Required by:
https://github.com/doofinder/support/issues/1606
https://github.com/doofinder/support/issues/1513
https://github.com/doofinder/support/issues/1599