### PR TITLE
PLUGINRANGERS-24 | Point update on save to Dooplugins

### DIFF
--- a/ApiClient/Client.php
+++ b/ApiClient/Client.php
@@ -29,6 +29,9 @@ class Client
     /** Search API type */
     public const SEARCH_API = 'search';
 
+    /** Dooplugins type */
+    public const DOOPLUGINS = 'dooplugins';
+
     /** @var StoreConfig */
     private $storeConfig;
 
@@ -270,6 +273,10 @@ class Client
      */
     private function getApiBaseURL(): string
     {
+        if ($this->apiType === self::DOOPLUGINS)
+        {
+            return sprintf("https://%s-plugins.doofinder.com", $this->clusterRegion);
+        }
         return sprintf("https://%s-%s.doofinder.com", $this->clusterRegion, $this->apiType);
     }
 

--- a/ApiClient/ManagementClient.php
+++ b/ApiClient/ManagementClient.php
@@ -16,7 +16,7 @@ use Doofinder\Feed\Errors\WrongResponse;
 class ManagementClient
 {
     private const ENDPOINT_SEARCH_ENGINES = '/api/v2/search_engines';
-    private const ENDPOINT_UPDATE_ON_SAVE = '/plugins/magento2';
+    private const ENDPOINT_UPDATE_ON_SAVE = '/magento2';
 
     /** @var Client */
     private $client;

--- a/Helper/Item.php
+++ b/Helper/Item.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doofinder\Feed\Helper;
 
 use Doofinder\Feed\Api\Data\ChangedItemInterface;
+use Doofinder\Feed\ApiClient\Client;
 use Doofinder\Feed\ApiClient\ManagementClientFactory;
 use Doofinder\Feed\Errors\BadRequest;
 use Doofinder\Feed\Errors\IndexingInProgress;
@@ -155,7 +156,7 @@ class Item extends AbstractHelper
         $hashId = $searchEngine['hashid'];
         $this->validateIndice($searchEngine, $indice);
         $managementClient = $this->throttleFactory->create([
-            'obj' => $this->managementClientFactory->create(['apiType' => 'admin']),
+            'obj' => $this->managementClientFactory->create(['apiType' => Client::DOOPLUGINS]),
         ]);
 
         switch ($type) {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.13.5",
+    "version": "0.13.6",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.13.5">
+    <module name="Doofinder_Feed" setup_version="0.13.6">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:
- https://github.com/doofinder/dooplugins/issues/24

Basically points the previous endpoint to Dooplugins instead of being pointed to Doomanager.