### PR TITLE
PLUGINRANGERS-1823 | Removed image_size field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.13.5",
+    "version": "0.13.6",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -127,18 +127,6 @@
                         <![CDATA[ Configure when registered product changes are sent to Doofinder ]]>
                     </comment>
                 </field>
-                <field id="image_size"
-                       translate="label"
-                       type="text"
-                       sortOrder="400"
-                       showInDefault="0"
-                       showInWebsite="0"
-                       showInStore="0">
-                    <label>Image size</label>
-                    <comment>
-                        <![CDATA[Export product image with given width. Leave empty to use original size.]]>
-                    </comment>
-                </field>
                 <field id="categories_in_navigation"
                        translate="label"
                        type="select"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.13.5">
+    <module name="Doofinder_Feed" setup_version="0.13.6">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:
- https://github.com/doofinder/support/issues/1823

This field were no longer being used, so we're going to remove it.