### PR TITLE
PLUGINRANGERS-2316 | Fixed dependency injection on parent construct to avoid issues with Magento 2.4.7

### DIFF
--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -108,7 +108,6 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
         $this->excludedCustomAttributes = ['special_price', 'special_from_date', 'special_to_date'];
         parent::__construct(
             $productFactory,
-            $initializationHelper,
             $searchResultsFactory,
             $collectionFactory,
             $searchCriteriaBuilder,

--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -9,7 +9,6 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\Data\ProductSearchResultsInterfaceFactory;
 use Magento\Catalog\Api\CategoryListInterface;
 use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
-use Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper;
 use Magento\Catalog\Helper\Image as ImageHelper;
 use Magento\Catalog\Helper\ImageFactory;
 use Magento\Catalog\Model\Product;
@@ -71,7 +70,6 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
         StoreConfig $storeConfig,
         MagentoStoreConfig $magentoStoreConfig,
         ProductFactory $productFactory,
-        Helper $initializationHelper,
         ProductSearchResultsInterfaceFactory $searchResultsFactory,
         ProductCollectionFactory $collectionFactory,
         SearchCriteriaBuilder $searchCriteriaBuilder,

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.13.13",
+    "version": "0.13.14",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.13.13">
+    <module name="Doofinder_Feed" setup_version="0.13.14">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2316

In the image, the error is shown and then the result after applying this fix

![image](https://github.com/doofinder/doofinder-magento2/assets/128705267/bcdeda1e-7087-4d14-bf14-ccef23173454)

Original parent constructor:

![image](https://github.com/doofinder/doofinder-magento2/assets/128705267/260231df-ffd9-4154-8bc7-9cabe760341a)

