### PR TITLE
Compatible with Magento 2.4.7 - Backward compatibility has been lost in the Magento\Catalog\Model\ProductRepository class

### DIFF
--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -31,6 +31,7 @@ use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\App\Area;
+use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\EntityManager\Operation\Read\ReadExtensions;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filesystem;
@@ -50,6 +51,7 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
 {
     protected $imageHelperFactory;
     protected $appEmulation;
+    private $productMetadataInterface;
     private $stockRegistry;
     private $cacheLimit = 0;
     private $productHelperFactory;
@@ -61,6 +63,7 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
     private $categoryListInterface;
 
     public function __construct(
+        ProductMetadataInterface $productMetadataInterface,
         ImageFactory $imageHelperFactory,
         Emulation $appEmulation,
         StockRegistryInterface $stockRegistry,
@@ -106,32 +109,60 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
         $this->magentoStoreConfig = $magentoStoreConfig;
         //Add here any custom attributes we want to exclude from indexation
         $this->excludedCustomAttributes = ['special_price', 'special_from_date', 'special_to_date'];
-        parent::__construct(
-            $productFactory,
-            $initializationHelper,
-            $searchResultsFactory,
-            $collectionFactory,
-            $searchCriteriaBuilder,
-            $attributeRepository,
-            $resourceModel,
-            $linkInitializer,
-            $linkTypeProvider,
-            $storeManager,
-            $filterBuilder,
-            $metadataServiceInterface,
-            $extensibleDataObjectConverter,
-            $optionConverter,
-            $fileSystem,
-            $contentValidator,
-            $contentFactory,
-            $mimeTypeExtensionMap,
-            $imageProcessor,
-            $extensionAttributesJoinProcessor,
-            $collectionProcessor,
-            $serializer,
-            $cacheLimit,
-            $readExtensions
-        );
+        if (version_compare($productMetadataInterface->getVersion(), '2.4.7', '>=')) {
+            parent::__construct(
+                $productFactory,
+                $searchResultsFactory,
+                $collectionFactory,
+                $searchCriteriaBuilder,
+                $attributeRepository,
+                $resourceModel,
+                $linkInitializer,
+                $linkTypeProvider,
+                $storeManager,
+                $filterBuilder,
+                $metadataServiceInterface,
+                $extensibleDataObjectConverter,
+                $optionConverter,
+                $fileSystem,
+                $contentValidator,
+                $contentFactory,
+                $mimeTypeExtensionMap,
+                $imageProcessor,
+                $extensionAttributesJoinProcessor,
+                $collectionProcessor,
+                $serializer,
+                $cacheLimit,
+                $readExtensions
+            );
+        } else {
+            parent::__construct(
+                $productFactory,
+                $initializationHelper,
+                $searchResultsFactory,
+                $collectionFactory,
+                $searchCriteriaBuilder,
+                $attributeRepository,
+                $resourceModel,
+                $linkInitializer,
+                $linkTypeProvider,
+                $storeManager,
+                $filterBuilder,
+                $metadataServiceInterface,
+                $extensibleDataObjectConverter,
+                $optionConverter,
+                $fileSystem,
+                $contentValidator,
+                $contentFactory,
+                $mimeTypeExtensionMap,
+                $imageProcessor,
+                $extensionAttributesJoinProcessor,
+                $collectionProcessor,
+                $serializer,
+                $cacheLimit,
+                $readExtensions
+            );
+        }
     }
 
     /**
@@ -376,7 +407,7 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
                 $categoryIds[$category->getCategoryId()] = true;
             }
         }
-        
+
         // Get table name with prefix if it exists
         $catalogCategoryEntityTable = $this->resourceModel->getTable('catalog_category_entity');
 

--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -51,7 +51,6 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
 {
     protected $imageHelperFactory;
     protected $appEmulation;
-    private $productMetadataInterface;
     private $stockRegistry;
     private $cacheLimit = 0;
     private $productHelperFactory;

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.13.13",
+    "version": "0.13.14",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.13.13">
+    <module name="Doofinder_Feed" setup_version="0.13.14">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
As of Magento 2.4.7, backward compatibility has been lost in the Magento\Catalog\Model\ProductRepository class. This pull request aims to fix this issue.

Check the issue page in the Magento repo for reference: https://github.com/magento/magento2/issues/38669.