### PR TITLE
fix: Use prices from same variant for parent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.13.17",
+    "version": "0.13.18",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.13.17">
+    <module name="Doofinder_Feed" setup_version="0.13.18">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by #322.

The prices that were being used for the parent product were obtained from the minimum prices of the variant. However, it was allowing the prices to be taken from different variants (the price from one variant and the sale_price from another) which is not coherent