### PR TITLE
PLUGINRANGERS-2486 | Changed getLayerScript method to fix a critical issue

### DIFF
--- a/Helper/StoreConfig.php
+++ b/Helper/StoreConfig.php
@@ -546,7 +546,7 @@ class StoreConfig extends AbstractHelper
                 $language = $lang_parts[0];
 
                 $singleScriptAdditionalConfig = <<<EOT
-                    <script data-additional-config>
+                    <script>
                         (function(w, k) {w[k] = window[k] || function () { (window[k].q = window[k].q || []).push(arguments) }})(window, "doofinderApp")
                     
                         doofinderApp("config", "language", "$language")

--- a/Helper/StoreConfig.php
+++ b/Helper/StoreConfig.php
@@ -972,59 +972,6 @@ class StoreConfig extends AbstractHelper
     }
 
     /**
-     * Function to include the locale and the currency into the script.
-     * 
-     * IMPORTANT NOTE: Once the single script is released, this method
-     * will become deprecated and it will be removed soon.
-     * 
-     * The following entries are covered:
-     *    const dfLayerOptions = {
-     *      installationId: '4aa94cbd-e2a0-44db-b1d2-f0817ad2a97d',
-     *      zone: 'eu1',
-     *      currency: 'USD',
-     *      language: 'fr-FR'
-     *    };
-     *
-     *    const dfLayerOptions = {
-     *      installationId: '4aa94cbd-e2a0-44db-b1d2-f0817ad2a97d',
-     *      zone: 'eu1',
-     *      //currency: 'USD',
-     *      //language: 'fr-FR'
-     *    };
-     *
-     *    const dfLayerOptions = {
-     *      installationId: '4aa94cbd-e2a0-44db-b1d2-f0817ad2a97d',
-     *      zone: 'eu1'
-     *    };
-     *
-     * @return string
-     *    const dfLayerOptions = {
-     *      installationId: '4aa94cbd-e2a0-44db-b1d2-f0817ad2a97d',
-     *      zone: 'eu1',
-     *      currency: 'USD',
-     *      language: 'fr-FR'
-     *    };
-     */
-    private function includeLocaleAndCurrency($liveLayerScript, $locale, $currency): string
-    {
-        if (strpos($liveLayerScript, 'language:') !== false) {
-            $liveLayerScript = preg_replace("/(\/\/\s*)?(language:)(.*?)(\n|,)/m", "$2 '$locale'$4", $liveLayerScript);
-        } else {
-            $pos = strpos($liveLayerScript, "{");
-            $liveLayerScript = substr_replace($liveLayerScript, "\r\n\tlanguage: '$locale',", $pos+1, 0);
-        }
-
-        if (strpos($liveLayerScript, 'currency:') !== false) {
-            $liveLayerScript = preg_replace("/(\/\/\s*)?(currency:)(.*?)(\n|,)/m", "$2 '$currency'$4", $liveLayerScript);
-        } else {
-            $pos = strpos($liveLayerScript, "{");
-            $liveLayerScript = substr_replace($liveLayerScript, "\r\n\tcurrency: '$currency',", $pos+1, 0);
-        }
-
-        return $liveLayerScript;
-    }
-
-    /**
      * Get stores by store_group id
      *
      * @param int $storeGroupId

--- a/Helper/StoreConfig.php
+++ b/Helper/StoreConfig.php
@@ -538,10 +538,24 @@ class StoreConfig extends AbstractHelper
                 (int)$storeGroupId
             );
 
-            if ($displayLayerScript != null) {
-                $locale = $this->getLanguageFromStore($this->getCurrentStore());
-                $currency = $this->getCurrentStore()->getCurrentCurrency()->getCode();
-                $displayLayerScript = $this->includeLocaleAndCurrency($displayLayerScript, $locale, $currency);
+            if (1 !== preg_match('/doofinderApp/', $displayLayerScript)) {
+                $store = $this->getCurrentStore();
+                $currency = $store->getCurrentCurrency()->getCode();
+                $language_country = $this->getLanguageFromStore($store);
+                $lang_parts = explode('-', $language_country);
+                $language = $lang_parts[0];
+
+                $singleScriptAdditionalConfig = <<<EOT
+                    <script data-additional-config>
+                        (function(w, k) {w[k] = window[k] || function () { (window[k].q = window[k].q || []).push(arguments) }})(window, "doofinderApp")
+                    
+                        doofinderApp("config", "language", "$language")
+                        doofinderApp("config", "currency", "$currency")
+                    </script>
+
+                EOT;
+
+                $displayLayerScript = $singleScriptAdditionalConfig . $displayLayerScript;
             }
         } catch (\Exception $e) {
             $displayLayerScript = null;

--- a/Model/SingleScript.php
+++ b/Model/SingleScript.php
@@ -91,25 +91,15 @@ class SingleScript
             $websiteId = $website->getId();
             foreach ($this->storeConfig->getWebsiteStores($websiteId) as $store) {
                 $installationId = $this->getInstallationId($store);
-                $currency = $store->getCurrentCurrencyCode();
-                $language = $this->getTwoLettersLanguage($this->storeConfig->getLanguageFromStore($store));
                 $region = $this->getRegionFromApiKey();
-                if (empty($installationId) || empty($currency) || empty($language || empty($region))) {
+                if (empty($installationId) || empty($region)) {
                     continue;
                 }
                 
-                $singleScript = <<<EOT
-                    <script>
-                        (function(w, k) {w[k] = window[k] || function () { (window[k].q = window[k].q || []).push(arguments) }})(window, "doofinderApp")
-                    
-                        doofinderApp("config", "language", "$language")
-                        doofinderApp("config", "currency", "$currency")
-                    </script>
-                    <script src="https://$region-config.doofinder.com/2.x/$installationId.js" async></script>  
-                EOT;
+                $singleScript = '<script src="https://' . $region . '-config.doofinder.com/2.x/' . $installationId . '.js" async></script>';
 
                 $storeGroupId = $store->getStoreGroupId();
-                $scripts[$language] = trim($singleScript);
+                $scripts[] = trim($singleScript);
                 $this->storeConfig->setDisplayLayer($singleScript, $storeGroupId);
             }
         }
@@ -143,12 +133,6 @@ class SingleScript
         }
 
         return $region;
-    }
-
-    private function getTwoLettersLanguage(string $language_country): string 
-    {
-        $lang_parts = explode('-', $language_country);
-        return $lang_parts[0];
     }
 
     /*

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.14.1",
+    "version": "0.14.2",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.14.1">
+    <module name="Doofinder_Feed" setup_version="0.14.2">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2486

This version only adds the extra doofinderApp data in case it comes from a brand new installation which may not include this part. However, for migrated ones that already includes it directly in the database, it won't be added twice.

![image](https://github.com/doofinder/doofinder-magento2/assets/128705267/15572ecb-d12e-4d6a-9f9c-a10ba79b1051)

In case it's a brand new installation, an additional data will be added on the script tag to be able to discern the cases more easily