### PR TITLE
Sofia/magento2_support_issues

### DIFF
--- a/Model/Config/Backend/Cron.php
+++ b/Model/Config/Backend/Cron.php
@@ -16,7 +16,7 @@ use Magento\Framework\Registry;
 
 class Cron extends ConfigValue
 {
-    public const CRON_STRING_PATH = 'crontab/default/jobs/doofinder_update_on_save/schedule/cron_expr';
+    public const CRON_STRING_PATH = 'doofinder_config_config/update_on_save/cron_expression';
 
     protected $storeConfigFactory;
 

--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -366,6 +366,9 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                 ->getValueFromConfig("doofinder_config_config/doofinder_image/doofinder_image_size")
             ));
 
+        $configurableProductsOptions = $extensionAttributes->getConfigurableProductOptions();
+        $extensionAttributes->setConfigurableProductOptions($this->updateConfigurableProductOptions($configurableProductsOptions));
+
         $product->setExtensionAttributes($extensionAttributes);
     }
 
@@ -436,5 +439,23 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         }
 
         return $categoryResults;
+    }
+
+    private function updateConfigurableProductOptions($configurableProductsOptions){
+        $eavConfig  = ObjectManager::getInstance()->get('\Magento\Eav\Model\Config');
+        $configurableProductsOptionsResult = [];
+
+        if($configurableProductsOptions != NULL) {
+            foreach ($configurableProductsOptions as $configurableProductOption) {
+                $attribute = $eavConfig->getAttribute('catalog_product', $configurableProductOption->getAttributeId());
+                $configurableProductsOptionsResult[] = [
+                    'attribute_id' => $configurableProductOption->getAttributeId(),
+                    'label' => $configurableProductOption->getLabel(),
+                    'code' => $attribute->getAttributeCode(),
+                    'product_id' => $configurableProductOption->getProductId()
+                ];
+            }
+        }
+        return $configurableProductsOptionsResult;
     }
 }

--- a/Observer/Product/AbstractChangedProductObserver.php
+++ b/Observer/Product/AbstractChangedProductObserver.php
@@ -119,6 +119,7 @@ abstract class AbstractChangedProductObserver implements ObserverInterface
         $itemsToInsert = [$itemId];
         $parentProducts = $this->configurableProductType->getParentIdsByChild($itemId);
         if (count($parentProducts) > 0) {
+            /* When updating a product it's children are also updated, so in this case we include the parentId but don't need to specify the itemId */
             $itemsToInsert = $parentProducts;
         }
         

--- a/Observer/Product/AbstractChangedProductObserver.php
+++ b/Observer/Product/AbstractChangedProductObserver.php
@@ -121,6 +121,7 @@ abstract class AbstractChangedProductObserver implements ObserverInterface
         if (count($parentProduct) > 0) {
             $itemsToInsert = $parentProduct;
         }
+        
         foreach ($itemsToInsert as $itemToInsert) {
             $changedItem = $this->createChangedItem((int)$itemToInsert, $storeId);
             if (!$this->changedItemRepository->exists($changedItem)) {

--- a/Observer/Product/AbstractChangedProductObserver.php
+++ b/Observer/Product/AbstractChangedProductObserver.php
@@ -117,9 +117,9 @@ abstract class AbstractChangedProductObserver implements ObserverInterface
         $itemId = $product->getId();
 
         $itemsToInsert = [$itemId];
-        $parentProduct = $this->configurableProductType->getParentIdsByChild($itemId);
-        if (count($parentProduct) > 0) {
-            $itemsToInsert = $parentProduct;
+        $parentProducts = $this->configurableProductType->getParentIdsByChild($itemId);
+        if (count($parentProducts) > 0) {
+            $itemsToInsert = $parentProducts;
         }
         
         foreach ($itemsToInsert as $itemToInsert) {

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -53,7 +53,7 @@ class Uninstall implements UninstallInterface
         }
         //remove cron entries
         $collection = $this->collectionFactory->create();
-        $collection->addFieldToFilter('path', 'crontab/default/jobs/doofinder_update_on_save/schedule/cron_expr');
+        $collection->addFieldToFilter('path', 'doofinder_config_config/update_on_save/cron_expression');
         $config = $collection->getFirstItem();
         $this->deleteConfig($config);
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.14.3",
+    "version": "0.14.4",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="default">
         <job name="doofinder_update_on_save" instance="Doofinder\Feed\Cron\Processor" method="execute">
-            <config_path>crontab/default/jobs/doofinder_update_on_save/schedule/cron_expr</config_path>
+            <config_path>doofinder_config_config/update_on_save/cron_expression</config_path>
         </job>
     </group>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.14.3">
+    <module name="Doofinder_Feed" setup_version="0.14.4">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/2572
Required by: https://github.com/doofinder/support/issues/2569

Estamos teniendo algunos problemas con los update on save de magento.

- Al indexar variantes llega que el tipo es simple y por lo tanto lo trata como un producto simple y le asigna su propio group_id por lo que se pierde la agrupación. Se ha modificado para que si se actualiza un producto variante se mande el update on save de su producto padre para que se actualice el padre y sus variantes.

- Tenemos un nombramiento mezclado del cron job, en algunos sitios se llamaba como `doofinder_config_config/update_on_save/cron_expression` y en otros `crontab/default/jobs/doofinder_update_on_save/schedule/cron_expr`, se estaban creando dos entradas en base de datos cuando en realidad sólo necesitamos uno.
![image](https://github.com/user-attachments/assets/6940c7eb-39fc-4e49-a553-f2df6406bfdd)

- Hay una incongruencia entre lo que indexamos en el `df_variants_information` y lo que después se indexa en la variante, en el producto padre estamos utilizando el label del atributo y en la variante el code, por lo que después no funciona el botón del add to cart correctamente. Se ha modificado para que a itemsTransformation le llegue este `code` y poder utilizarlo.