### PR TITLE
First draft changes for the plugin

### DIFF
--- a/Controller/Adminhtml/Integration/CreateStore.php
+++ b/Controller/Adminhtml/Integration/CreateStore.php
@@ -139,7 +139,6 @@ class CreateStore extends Action implements HttpGetActionInterface
 
         foreach ($this->storeConfig->getStoreGroupStores($storeGroupId) as $store) {
             $language = $this->storeConfig->getLanguageFromStore($store);
-            $currency = strtoupper($store->getCurrentCurrency()->getCode());
             $store_id = $store->getId();
             $base_url = $store->getBaseUrl();
 
@@ -147,7 +146,6 @@ class CreateStore extends Action implements HttpGetActionInterface
             $searchEngineConfig[] = [
                 "name" => $store->getName(),
                 "language" => $language,
-                "currency" => $currency,
                 "site_url" => $base_url,
                 "callback_url" => $base_url . 'doofinderfeed/setup/processCallback?storeId=' . $store_id,
                 "options" => [
@@ -156,7 +154,7 @@ class CreateStore extends Action implements HttpGetActionInterface
                 ]
             ];
 
-            $storesConfig[$language][$currency] = (int)$store_id;
+            $storesConfig[$language] = (int)$store_id;
         }
         return [
             "searchEngineConfig" => $searchEngineConfig,
@@ -201,26 +199,24 @@ class CreateStore extends Action implements HttpGetActionInterface
      * "search_engines":{"de":{"USD":"024d8eb1caa649775d08f3f69ddf333a"},"en":{"USD":"c3981a773ac987e5828c94677cda237f"}}
      * We're going to iterate over the search_engines because there is the data created in doofinder. May occour that some
      * of the data that we've in storeConfig has some invalid parameter and will be bypass during the creation.
-     * 
+     *
      * @param $storesConfig
      * @param $searchEngines
      */
     private function saveSearchEngineConfig($storesConfig, $searchEngines)
     {
-        foreach ($searchEngines as $language => $values) {
-            foreach ($values as $currency => $hashid) {
-                $storeId = $storesConfig[$language][$currency];
-                $this->storeConfig->setHashId($hashid, $storeId);
-                $this->setIndexationStatus($storeId);
-            }
+        foreach ($searchEngines as $language => $hashid) {
+            $storeId = $storesConfig[$language];
+            $this->storeConfig->setHashId($hashid, $storeId);
+            $this->setIndexationStatus($storeId);
         }
     }
 
     /**
      * Function to store the status of the SE indexation.
-     * 
+     *
      * By default we set this value to "STARTED" and will be updated when we receive the callback from doofinder
-     * 
+     *
      * @param $storeId
      */
     private function setIndexationStatus($storeId)

--- a/Helper/StoreConfig.php
+++ b/Helper/StoreConfig.php
@@ -540,6 +540,7 @@ class StoreConfig extends AbstractHelper
 
             if (!empty($displayLayerScript) && 1 !== preg_match('/dfLayerOptions/', $displayLayerScript) && 1 !== preg_match('/doofinderApp/', $displayLayerScript)) {
                 $store = $this->getCurrentStore();
+                //TODO: Adapt in case layer needs the info in a different format
                 $currency = $store->getCurrentCurrency()->getCode();
                 $language_country = $this->getLanguageFromStore($store);
                 $lang_parts = explode('-', $language_country);

--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -298,7 +298,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      */
     private function setCustomAttributes($product, $storeId): void
     {
-        $productHelper = $this->productHelperFactory->create();
         $priceHelper = $this->priceHelperFactory->create();
         $store = $this->storeManager->getStore($storeId);
         $customAttributes = $this->storeConfig->getCustomAttributes($product->getStoreId());

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -8,5 +8,6 @@
         <attribute code="image" type="string"/>
         <attribute code="price" type="float"/>
         <attribute code="special_price" type="float"/>
+        <attribute code="prices" type="string"/>
     </extension_attributes>
 </config>


### PR DESCRIPTION
Changes required by the Magento plugin to multiprice search engines.

### Decisions

- The feed URL depends on the Store View. Hence, it looked like a bad idea to mix several Store Views into one Search Engine.
- Also, it looks like the function of the Store Views is mainly translations (it allows for different languages to be set) and not multicurrency.
- What we do right now is consider the **Default Display Currency** for a Store View and use it as the currency of the Search Engine.
- However, it might be time to reconsider this as the real configuration for the allowed currencies for a Store View is actually in the **Allowed Currencies** field which can also be configured at Store View level.
![image](https://github.com/user-attachments/assets/588f46eb-a5f1-4477-838b-e772c3fdaa42)
- If we use this, now we would have a Search Engine per Store View (configuring different languages) and a number of allowed currencies, which would configure the prices for every product in that Search Engine (this would be much similar to what we are doing with the other platforms).

### Open Items / Questions

- How are we going to handle the retrocompatibility/deployment?
- Is there any update needed in the script?
- Is there any update needed due to changes in the Installation search engine mapping?
- How are we going to determine which currency symbol to use?
- Is there any update on the response of the Doomanager create store request?
