### PR TITLE
PLUGINRANGERS-2698 | Version bump to 0.14.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.14.7",
+    "version": "0.14.8",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.14.7">
+    <module name="Doofinder_Feed" setup_version="0.14.8">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2698

Since I didn't increase the version in the bugfix, the previous version had the bug flagged as solved here: https://github.com/doofinder/doofinder-magento2/pull/343. However, the ZIP used the version that still had the bug, so this version bump will solve it definitely. 