### PR TITLE
Fix marketplace test issue

### DIFF
--- a/Cron/Processor.php
+++ b/Cron/Processor.php
@@ -1,4 +1,18 @@
 <?php
+/**
+ * By removing the UNIQUE restriction from our table, it happens that during imports or product generation with fixtures, 
+ * duplicate elements are inserted into the table. These operations are handled within transactions and it seems that our code 
+ * is currently not able to determine if the element is already added when it is within a transaction.
+ * 
+ * As a result, when executing the Processor for the Update on Save, we receive more elements than we actually need to process, 
+ * because many of them are duplicates.
+ * 
+ * So what we do here is clone the original collection that has all the ungrouped elements. 
+ * Then, a group is applied to the copy and thus we ensure that we process unique elements. 
+ * At the end, the elements of the original collection are deleted from the table.
+ * 
+ * This logic is applied in the same way in the others two functions updateItems and deleteItems.
+ */
 
 declare(strict_types=1);
 
@@ -122,20 +136,7 @@ class Processor
     {
         $collection = $this->changedItemCollectionFactory->create()->filterCreated((int)$store->getId(), $itemType);
         
-        /**
-         * By removing the UNIQUE restriction from our table, it happens that during imports or product generation with fixtures, 
-         * duplicate elements are inserted into the table. These operations are handled within transactions and it seems that our code 
-         * is currently not able to determine if the element is already added when it is within a transaction.
-         * 
-         * As a result, when executing the Processor for the Update on Save, we receive more elements than we actually need to process, 
-         * because many of them are duplicates.
-         * 
-         * So what we do here is clone the original collection that has all the ungrouped elements. 
-         * Then, a group is applied to the copy and thus we ensure that we process unique elements. 
-         * At the end, the elements of the original collection are deleted from the table.
-         * 
-         * This logic is applied in the same way in the others two functions updateItems and deleteItems.
-         */
+        // Avoid process more than once the same product due to Magento2 product import process.
         $groupedCollection = clone $collection;
         $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
 
@@ -173,7 +174,7 @@ class Processor
     {
         $collection = $this->changedItemCollectionFactory->create()->filterUpdated((int)$store->getId(), $itemType);
 
-        // In the createItems function you can find the explanation of why this logic with the collection is necessary.
+        // Avoid process more than once the same product due to Magento2 product import process.
         $groupedCollection = clone $collection;
         $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
 
@@ -211,7 +212,7 @@ class Processor
     {
         $collection = $this->changedItemCollectionFactory->create()->filterDeleted((int)$store->getId(), $itemType);
 
-        // In the createItems function you can find the explanation of why this logic with the collection is necessary.
+        // Avoid process more than once the same product due to Magento2 product import process.
         $groupedCollection = clone $collection;
         $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
 

--- a/Cron/Processor.php
+++ b/Cron/Processor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doofinder\Feed\Cron;
 
+use Doofinder\Feed\Api\Data\ChangedItemInterface;
 use Doofinder\Feed\Helper\Item as ItemHelper;
 use Doofinder\Feed\Helper\StoreConfig;
 use Doofinder\Feed\Model\ChangedItem\DocumentsProvider;
@@ -120,8 +121,12 @@ class Processor
     private function createItems($store, $itemType, $indice)
     {
         $collection = $this->changedItemCollectionFactory->create()->filterCreated((int)$store->getId(), $itemType);
-        if ($collection->getSize()) {
-            $created = $this->documentsProvider->getBatched($collection, (int)$store->getId());
+        
+        $groupedCollection = clone $collection;
+        $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
+
+        if ($groupedCollection->getSize()) {
+            $created = $this->documentsProvider->getBatched($groupedCollection, (int)$store->getId());
             foreach ($this->batch->getItems($created, $this->batchSize) as $batchDocuments) {
                 $items = $this->mapItems($batchDocuments);
                 if (count($items)) {
@@ -153,8 +158,12 @@ class Processor
     private function updateItems($store, $itemType, $indice)
     {
         $collection = $this->changedItemCollectionFactory->create()->filterUpdated((int)$store->getId(), $itemType);
-        if ($collection->getSize()) {
-            $updated = $this->documentsProvider->getBatched($collection, (int)$store->getId());
+
+        $groupedCollection = clone $collection;
+        $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
+
+        if ($groupedCollection->getSize()) {
+            $updated = $this->documentsProvider->getBatched($groupedCollection, (int)$store->getId());
             foreach ($this->batch->getItems($updated, $this->batchSize) as $batchDocuments) {
                 $items = $this->mapItems($batchDocuments);
                 if (count($items)) {
@@ -186,8 +195,12 @@ class Processor
     private function deleteItems($store, $itemType, $indice)
     {
         $collection = $this->changedItemCollectionFactory->create()->filterDeleted((int)$store->getId(), $itemType);
-        if ($collection->getSize()) {
-            $deleted = $this->documentsProvider->getBatched($collection);
+
+        $groupedCollection = clone $collection;
+        $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
+
+        if ($groupedCollection->getSize()) {
+            $deleted = $this->documentsProvider->getBatched($groupedCollection);
             foreach ($this->batch->getItems($deleted, $this->batchSize) as $batchDeleted) {
                 $items = $this->mapItems($batchDeleted);
                 if (count($items)) {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.14.11",
+    "version": "0.14.12",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -14,6 +14,6 @@
         </constraint>
         <constraint xsi:type="foreign" referenceId="DOOFINDER_FEED_CHANGED_ITEM_SKIP_ENTITY_ID_BINDING_FK"
                     table="doofinder_feed_changed_item" column="skip_entity_id_binding" 
-                    referenceTable="catalog_product_entity" referenceColumn="entity_id" onDelete="CASCADE"/>
+                    referenceTable="catalog_product_entity" referenceColumn="entity_id"/>
     </table>
 </schema>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -7,14 +7,13 @@
         <column xsi:type="int" name="store_id" nullable="false" comment="ID of store the change was issued on"/>
         <column xsi:type="smallint" name="item_type" nullable="false" comment="Type of item"/>
         <column xsi:type="varchar" name="operation_type" nullable="false" length="255" comment="Operation Type"/>
+        <column xsi:type="int" name="skip_entity_id_binding" unsigned="true" nullable="true" identity="false"
+            comment="Ignore Entity ID Binding"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="entity_id"/>
         </constraint>
-        <constraint xsi:type="unique" referenceId="DOOFINDER_FEED_CHANGED_ITEM_ITEM_ID_STORE_ID_OPERATION_TYPE_ITEM_TYPE">
-            <column name="item_id"/>
-            <column name="store_id"/>
-            <column name="operation_type"/>
-            <column name="item_type"/>
-        </constraint>
+        <constraint xsi:type="foreign" referenceId="DOOFINDER_FEED_CHANGED_ITEM_SKIP_ENTITY_ID_BINDING_FK"
+                    table="doofinder_feed_changed_item" column="skip_entity_id_binding" 
+                    referenceTable="catalog_product_entity" referenceColumn="entity_id" onDelete="CASCADE"/>
     </table>
 </schema>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.14.11">
+    <module name="Doofinder_Feed" setup_version="0.14.12">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
A partir de la versión 0.14.9 ha comenzado a fallar la subida de versiones en Magento, al parecer es posible que hayan cambiado algo en el entorno de pruebas de ellos.

El caso es que falla al generar fixtures.

Después de verlo en conjunto todo el equipo, vimos que agregando una columna con nombre skip_entity_id_binding y con llave foránea que hace referencia a catalog_product_entity.entity_id.

Además había que quitar la restricción que no permites adicionar duplicados a la tabla nuestra.

Haciendo las pruebas me percaté que entonces el collection que se usa para procesar el Update on Save, viene con elementos duplicados, por lo cual he introducido un cambio para filtrar esos duplicados a la hora de procesar, pero eliminar todos los elementos como siempre.