### PR TITLE
PLUGINRANGERS-2943 | Excluded disabled variants from minimum price calculation

### DIFF
--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -6,6 +6,7 @@ namespace Doofinder\Feed\Helper;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableType;
 use Magento\Downloadable\Model\Product\Type as DownloadableType;
 use Magento\GroupedProduct\Model\Product\Type\Grouped as GroupedType;
@@ -194,6 +195,11 @@ class Price extends AbstractHelper
     {
         $minimum_price = null;
         $minimum_variant = null;
+
+        // To exclude disabled variants from the calculations
+        $usedProds = array_filter($usedProds, function($child) {
+            return Status::STATUS_ENABLED === (int)$child->getStatus();
+        });
 
         /*
         We identify the variant with the minimum final price (or price), and

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.14.13",
+    "version": "0.14.14",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.14.13">
+    <module name="Doofinder_Feed" setup_version="0.14.14">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2943

Proof that works:

Current Magento config for "Variable product" product:

![image](https://github.com/user-attachments/assets/13933cd7-76d2-4310-94b4-8dedd92d4d2c)

Before the fix:

![Image](https://github.com/user-attachments/assets/678bb413-5705-446a-bddf-8a77d1047225)

After the fix:


![Image](https://github.com/user-attachments/assets/cbb8800f-c30d-4356-85ad-4dc018fe6435)