### PR TITLE
Fix issue with fixtures

### DIFF
--- a/Cron/Processor.php
+++ b/Cron/Processor.php
@@ -1,24 +1,9 @@
 <?php
-/**
- * By removing the UNIQUE restriction from our table, it happens that during imports or product generation with fixtures, 
- * duplicate elements are inserted into the table. These operations are handled within transactions and it seems that our code 
- * is currently not able to determine if the element is already added when it is within a transaction.
- * 
- * As a result, when executing the Processor for the Update on Save, we receive more elements than we actually need to process, 
- * because many of them are duplicates.
- * 
- * So what we do here is clone the original collection that has all the ungrouped elements. 
- * Then, a group is applied to the copy and thus we ensure that we process unique elements. 
- * At the end, the elements of the original collection are deleted from the table.
- * 
- * This logic is applied in the same way in the others two functions updateItems and deleteItems.
- */
 
 declare(strict_types=1);
 
 namespace Doofinder\Feed\Cron;
 
-use Doofinder\Feed\Api\Data\ChangedItemInterface;
 use Doofinder\Feed\Helper\Item as ItemHelper;
 use Doofinder\Feed\Helper\StoreConfig;
 use Doofinder\Feed\Model\ChangedItem\DocumentsProvider;
@@ -135,13 +120,8 @@ class Processor
     private function createItems($store, $itemType, $indice)
     {
         $collection = $this->changedItemCollectionFactory->create()->filterCreated((int)$store->getId(), $itemType);
-        
-        // Avoid process more than once the same product due to Magento2 product import process.
-        $groupedCollection = clone $collection;
-        $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
-
-        if ($groupedCollection->getSize()) {
-            $created = $this->documentsProvider->getBatched($groupedCollection, (int)$store->getId());
+        if ($collection->getSize()) {
+            $created = $this->documentsProvider->getBatched($collection, (int)$store->getId());
             foreach ($this->batch->getItems($created, $this->batchSize) as $batchDocuments) {
                 $items = $this->mapItems($batchDocuments);
                 if (count($items)) {
@@ -173,13 +153,8 @@ class Processor
     private function updateItems($store, $itemType, $indice)
     {
         $collection = $this->changedItemCollectionFactory->create()->filterUpdated((int)$store->getId(), $itemType);
-
-        // Avoid process more than once the same product due to Magento2 product import process.
-        $groupedCollection = clone $collection;
-        $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
-
-        if ($groupedCollection->getSize()) {
-            $updated = $this->documentsProvider->getBatched($groupedCollection, (int)$store->getId());
+        if ($collection->getSize()) {
+            $updated = $this->documentsProvider->getBatched($collection, (int)$store->getId());
             foreach ($this->batch->getItems($updated, $this->batchSize) as $batchDocuments) {
                 $items = $this->mapItems($batchDocuments);
                 if (count($items)) {
@@ -211,13 +186,8 @@ class Processor
     private function deleteItems($store, $itemType, $indice)
     {
         $collection = $this->changedItemCollectionFactory->create()->filterDeleted((int)$store->getId(), $itemType);
-
-        // Avoid process more than once the same product due to Magento2 product import process.
-        $groupedCollection = clone $collection;
-        $groupedCollection->getSelect()->group(ChangedItemInterface::ITEM_ID);
-
-        if ($groupedCollection->getSize()) {
-            $deleted = $this->documentsProvider->getBatched($groupedCollection);
+        if ($collection->getSize()) {
+            $deleted = $this->documentsProvider->getBatched($collection);
             foreach ($this->batch->getItems($deleted, $this->batchSize) as $batchDeleted) {
                 $items = $this->mapItems($batchDeleted);
                 if (count($items)) {

--- a/Helper/StoreConfig.php
+++ b/Helper/StoreConfig.php
@@ -34,7 +34,7 @@ use Magento\Backend\Helper\Data;
  */
 class StoreConfig extends AbstractHelper
 {
-    public const CRON_DISABLED_VALUE = 'everyday';
+    public const CRON_DISABLED_VALUE = '0 0 * * *';
     /**
      * URL to make the doofinder requests
      */

--- a/Model/ResourceModel/ChangedItem.php
+++ b/Model/ResourceModel/ChangedItem.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace Doofinder\Feed\Model\ResourceModel;
 
-use Magento\Framework\Model\ResourceModel\Db\AbstractDB;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 /**
  * The resource model of product change trace.
  */
-class ChangedItem extends AbstractDB
+class ChangedItem extends AbstractDb
 {
     /**
      * Holds the name of the table responsible for storing identities of deleted products.
@@ -17,6 +17,8 @@ class ChangedItem extends AbstractDB
      */
     public const TABLE_NAME = 'doofinder_feed_changed_item';
 
+    public const ENTITY_ID = 'entity_id';
+
     /**
      * Initializes resource model.
      *
@@ -24,9 +26,6 @@ class ChangedItem extends AbstractDB
      */
     protected function _construct()
     {
-        $this->_init(
-            self::TABLE_NAME,
-            'entity_id'
-        );
+        $this->_init(self::TABLE_NAME, self::ENTITY_ID);
     }
 }

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -7,13 +7,14 @@
         <column xsi:type="int" name="store_id" nullable="false" comment="ID of store the change was issued on"/>
         <column xsi:type="smallint" name="item_type" nullable="false" comment="Type of item"/>
         <column xsi:type="varchar" name="operation_type" nullable="false" length="255" comment="Operation Type"/>
-        <column xsi:type="int" name="skip_entity_id_binding" unsigned="true" nullable="true" identity="false"
-            comment="Ignore Entity ID Binding"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="entity_id"/>
         </constraint>
-        <constraint xsi:type="foreign" referenceId="DOOFINDER_FEED_CHANGED_ITEM_SKIP_ENTITY_ID_BINDING_FK"
-                    table="doofinder_feed_changed_item" column="skip_entity_id_binding" 
-                    referenceTable="catalog_product_entity" referenceColumn="entity_id"/>
+        <constraint xsi:type="unique" referenceId="DOOFINDER_FEED_CHANGED_ITEM_ITEM_ID_STORE_ID_OPERATION_TYPE_ITEM_TYPE">
+            <column name="item_id"/>
+            <column name="store_id"/>
+            <column name="operation_type"/>
+            <column name="item_type"/>
+        </constraint>
     </table>
 </schema>


### PR DESCRIPTION
Solucionado problema con los fixtures durante el CI del market de magento.

Finalmente el problema estaba relacionado con esta PR:
https://github.com/doofinder/doofinder-magento2/pull/346

Se modificó el valor por defecto del cron deshabilitado pero no se hizo el cambio en la constante que mira si hay que guardar los campos en nuestra tabla o no cuando hay un cambio. Esto estaba haciendo que aunque inicialmente el cron está deshabilitado se estuvieran intentando meter los fixtures en nuestra tabla y por eso fallaba.
![image](https://github.com/user-attachments/assets/d792525e-e9e4-4b87-9bf8-03adcda45ec5)

Se ha revertido lo que se hizo en este PR https://github.com/doofinder/doofinder-magento2/pull/353/files, porque realmente la definiciónd e la constraint estaba bien y se ha podido quitar lo del campo binding