### PR TITLE
Implementing hyva compatibility

### DIFF
--- a/Controller/Product/AddToCart.php
+++ b/Controller/Product/AddToCart.php
@@ -82,6 +82,7 @@ class AddToCart extends Action implements HttpPostActionInterface
 
         $params = new DataObject($params);
         $result = $quote->addProduct($product, $params);
+        $resultJson = $this->resultJsonFactory->create();
 
         if (is_a($result, QuoteItem::class)) {
             //Update totals
@@ -90,12 +91,13 @@ class AddToCart extends Action implements HttpPostActionInterface
             $quote->collectTotals();
             $this->cartRepository->save($quote);
             $session->replaceQuote($quote)->unsLastRealOrderId();
+
+            return $resultJson->setData(['success' => true]);
         } else {
             $this->logger->info("This product is variable, return the url");
             $product_url = $product->getProductUrl();
             $this->logger->info("Product url: ", ["product_url" => $product_url]);
 
-            $resultJson = $this->resultJsonFactory->create();
             return $resultJson->setData(['product_url' => $product_url]);
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "0.15.0",
+    "version": "1.0.0",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="0.15.0">
+    <module name="Doofinder_Feed" setup_version="1.0.0">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/view/frontend/layout/hyva_default.xml
+++ b/view/frontend/layout/hyva_default.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <!-- For hyva themes, jQuery can't be used among other modifications.
+        In that case we use a different JS  -->
+        <remove src="Doofinder_Feed::js/df_add_to_cart.js"/>
+        <script src="Doofinder_Feed::js/df_add_to_cart_hyva.js"/>
+    </head>
+    <body>
+        <referenceBlock name="head.additional">
+            <block
+                class="Doofinder\Feed\Block\Display\Layer"
+                name="doofinderfeed_display_layer"
+                as="doofinderfeed.display.layer"
+                template="Doofinder_Feed::display/layer.phtml"
+                ifconfig="doofinder_config_config/doofinder_layer/doofinder_layer_enabled"
+                after="-"/>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/frontend/web/js/df_add_to_cart_hyva.js
+++ b/view/frontend/web/js/df_add_to_cart_hyva.js
@@ -1,0 +1,60 @@
+class DoofinderAddToCartError extends Error {
+  constructor(reason, status = "") {
+    const message =
+      "Error adding an item to the cart. Reason: " +
+      reason +
+      ". Status code: " +
+      status;
+    super(message);
+    this.name = "DoofinderAddToCartError";
+  }
+}
+
+document.addEventListener("doofinder.cart.add", function (event) {
+  const { item_id, amount, statusPromise } = event.detail;
+  addToCart(item_id, amount, statusPromise);
+});
+
+function addToCart(item_id, amount, statusPromise) {
+  amount = !amount ? 1 : parseInt(amount);
+  item_id = parseInt(item_id);
+
+  const params = new URLSearchParams({
+    form_key: hyva.getFormKey(),
+    id: item_id,
+    qty: amount,
+  });
+
+  fetch(`${BASE_URL}doofinderfeed/Product/AddToCart?${params.toString()}`, {
+    method: "POST",
+  })
+    .then((response) => {
+      if (!response.ok) {
+        return response.text().then((error) => {
+          throw new Error(error);
+        });
+      }
+
+      return response.json();
+    })
+    .then((data) => {
+      if (data.product_url) {
+        statusPromise.reject(
+          new DoofinderAddToCartError(
+            "Configurable product. Redirecting to product URL",
+            200,
+          ),
+        );
+        window.location = data.product_url;
+        return;
+      }
+
+      statusPromise.resolve(
+        "The item has been successfully added to the cart.",
+      );
+      dispatchEvent(new Event("reload-customer-section-data"));
+    })
+    .catch((error) => {
+      statusPromise.reject(new DoofinderAddToCartError(error));
+    });
+}


### PR DESCRIPTION
Notas de la solución:
- Tal y como se explica [aquí](https://docs.hyva.io/hyva-themes/writing-code/the-hyva_-layout-handles.html), el tema hyva añado unos layout handle específico por cada layout normal configurado. Por lo tanto, es posible tener un layout que se utilice **únicamente** cuando estemos en un tema hyva añadiendo al nombre del layout el prefijo `hyva_`. Con esto y usando la opción de remove de los layouts, conseguimos renderizar únicamente el script correspondiente en función de si está instalado o no el tema hyva.
- Respecto al cambio en AddToCart.php, hasta el momento, únicamente devolvíamos un JSON en el caso de que se intentara añadir una variante. Para el caso de añadir un producto normal, no devolvíamos un JSON. Esto no es un problema cuando se usaba jQuery por cómo es la API `ajax()` de jQuery pero sí lo es cuando usamos `fetch()` y `json()` para procesar la respuesta. Por esto, se unifica lo que devolvemos para siempre devolver un JSON.