### PR TITLE
Don't index products with invalid visibility

### DIFF
--- a/Observer/Product/AbstractChangedProductObserver.php
+++ b/Observer/Product/AbstractChangedProductObserver.php
@@ -12,6 +12,7 @@ use Doofinder\Feed\Model\ChangedItem\ItemType;
 use Doofinder\Feed\Model\ChangedItemFactory;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Visibility;
 use \Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
@@ -45,6 +46,11 @@ abstract class AbstractChangedProductObserver implements ObserverInterface
     private $configurableProductType;
 
     /**
+     * @var []
+     */
+    private $visibilityAllowed;
+
+    /**
      * AbstractChangedProductObserver constructor.
      *
      * @param StoreConfig $storeConfig
@@ -65,6 +71,7 @@ abstract class AbstractChangedProductObserver implements ObserverInterface
         $this->changedItemRepository        = $changedItemRepository;
         $this->logger                       = $logger;
         $this->configurableProductType      = $configurableProductType;
+        $this->visibilityAllowed            =  [Visibility::VISIBILITY_IN_SEARCH, visibility::VISIBILITY_BOTH];
     }
 
     /**
@@ -78,6 +85,8 @@ abstract class AbstractChangedProductObserver implements ObserverInterface
                 $operationType = $this->getOperationType();
 
                 if ($product->getStatus() == Status::STATUS_DISABLED) {
+                    $this->setOperationType(ChangedItemInterface::OPERATION_TYPE_DELETE);
+                } elseif (!in_array($product->getVisibility(), $this->visibilityAllowed)){
                     $this->setOperationType(ChangedItemInterface::OPERATION_TYPE_DELETE);
                 } elseif ($product->getUpdatedAt() == $product->getCreatedAt() &&
                     $operationType == ChangedItemInterface::OPERATION_TYPE_UPDATE

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.0.0">
+    <module name="Doofinder_Feed" setup_version="1.0.1">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Ticket related: https://github.com/doofinder/support/issues/2997

Nosotros en la indexación no estamos indexando producto con visibility <= 2 (que significa que no son productos visibles individualmente ni productos que pertenecen sólo al catálogo), si no que tienen que sear searchables (que es visibilidad 3) o searchables, catalog que es visibilidad 4.

![image](https://github.com/user-attachments/assets/4302a609-f413-4d53-a85c-5139fb447edd)


Pero en el update on save no estamos excluyendo esos productos, por eso aparecían en el update on save pero se quitaban con la indexación.