### PR TITLE
PLUGINRANGERS-3073 | Avoid disabled products ids on configurable product links array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.0.1">
+    <module name="Doofinder_Feed" setup_version="1.0.2">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3073

2049 and 2050 appears:

![image](https://github.com/user-attachments/assets/087af530-2970-482f-8c23-a629346afc98)

But 2048 (the disabled one) doesn't:

![image](https://github.com/user-attachments/assets/99c6d4ac-77e3-462b-84fb-4e2ff45b7586)


