### PR TITLE
Take care deleting variants products

### DIFF
--- a/Observer/Product/AbstractChangedProductObserver.php
+++ b/Observer/Product/AbstractChangedProductObserver.php
@@ -100,7 +100,7 @@ abstract class AbstractChangedProductObserver implements ObserverInterface
                 }
                 
                 if ($product->getStore()->getId() == 0 ||
-                    $operationType == ChangedItemInterface::OPERATION_TYPE_DELETE
+                    $this->getOperationType() == ChangedItemInterface::OPERATION_TYPE_DELETE
                 ) {
                     foreach ($this->storeConfig->getAllStores() as $store) {
                         $this->registerChangedItemStore($product, (int)$store->getId());

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.0.2">
+    <module name="Doofinder_Feed" setup_version="1.0.3">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/3108

Estamos teniendo problemas en el update on save porque al borrar productos variantes se estamos eliminando del feed el producto padre en vez de la variante, esto viene por este PR: https://github.com/doofinder/doofinder-magento2/issues/334. Se ha añadido la condición de que añadimos a la base de datos el producto padre en vez de la variante sólo si estamos editando / creando, pero no para el borrado.

Además, haciendo pruebas he visto que con el cambio que se hizo en este PR (https://github.com/doofinder/doofinder-magento2/pull/358) para no incluir al feed los productos sin visibilidad esta provoando que si un producto simple se edita directamente lo marcamos como que hay que borrarlo en vez de actualizar su producto padre. Por eso a la condición de que si no tiene la visibildiad esperada lo borramos se le ha añadido la condición de que además no tenga producto padre, para excluir de esa eliminación a las variantes.