### PR TITLE
PLUGINRANGERS-3201 | Prevented CPU overload when adding an item to the cart

### DIFF
--- a/Controller/Product/AddToCart.php
+++ b/Controller/Product/AddToCart.php
@@ -86,11 +86,11 @@ class AddToCart extends Action implements HttpPostActionInterface
 
         if (is_a($result, QuoteItem::class)) {
             //Update totals
-            $quote->setTriggerRecollect(1);
             $quote->setIsActive(true);
-            $quote->collectTotals();
-            $this->cartRepository->save($quote);
+            $quote->collectTotals()->save();
             $session->replaceQuote($quote)->unsLastRealOrderId();
+            $cart = $this->cartRepository->get($quote->getId());
+            $this->cartRepository->save($cart);
 
             return $resultJson->setData(['success' => true]);
         } else {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "doofinder/doofinder-magento2",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Doofinder module for Magento 2",
     "type": "magento2-module",
     "require": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.0.5">
+    <module name="Doofinder_Feed" setup_version="1.0.6">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3201

There are several cases where Magento 2 can cause internal infinite loops as described on several posts: https://github.com/magento/magento2/issues/26786, https://magento.stackexchange.com/questions/303528/magento-2-3-4-infinite-loop-on-checkout-buttons, etc.

We've also discover that `$quote->setTriggerRecollect(1);` method was also causing an internal infinite loop, so we have modified the logic to avoid this issue.

I've just tested it on another Magento installation and it works as expected:

[Screencast from 18-02-25 12:58:44.webm](https://github.com/user-attachments/assets/7da6c945-24c0-4806-a87a-05a465fe1667)

