### PR TITLE
Added create release workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,11 @@
 /build\.sh                  export-ignore
 /\.github                   export-ignore
 /\.env                      export-ignore
+/\.env\.example             export-ignore
 /README.md                  export-ignore
 /build_release\.sh          export-ignore
 /default.vcl                export-ignore
+/phpcs\.xml                 export-ignore
+/Makefile                   export-ignore
+/data_loader\.sh            export-ignore
+/composer-ci\.json          export-ignore

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,29 @@
+name: Create Release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  create-release:
+    name: Build & Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install zip (if needed)
+        run: apt-get update && apt-get install -y git
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Create ZIP archive
+        id: vars
+        run: |
+          tag=${GITHUB_REF#refs/*/}
+          zip_path="doofinder-magento2-${GITHUB_REF#refs/*/}.zip"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+          echo "zip_path=$zip_path" >> $GITHUB_OUTPUT
+          git archive --format=zip -o $zip_path $tag
+      - name: Create release & upload asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ steps.vars.outputs.zip_path }}
+          name: Doofinder for Magento 2 - ${{ steps.vars.outputs.tag }}
+          generate_release_notes: true


### PR DESCRIPTION
## Required by
- https://github.com/doofinder/shopware5/issues/74

## Changelog
- Added a workflow that will generate a new release including zip file when a tag is created.

Release example:
![image](https://github.com/user-attachments/assets/40ea95b5-f5bc-4c0d-a0bd-cf1d577fbb22)