### PR TITLE
Use `StoreManagerInterface` to get frontend store url

### DIFF
--- a/Doofinder/Feed/Block/Adminhtml/Setup.php
+++ b/Doofinder/Feed/Block/Adminhtml/Setup.php
@@ -12,7 +12,7 @@ use Magento\Integration\Api\IntegrationServiceInterface;
 use Magento\Integration\Model\Integration;
 use Magento\Integration\Model\ResourceModel\Integration\Collection as IntegrationCollection;
 use Magento\Integration\Model\ResourceModel\Integration\CollectionFactory as IntegrationCollectionFactory;
-use Magento\Backend\Helper\Data;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Setup extends Template
 {
@@ -32,9 +32,9 @@ class Setup extends Template
     private $encryptor;
 
     /**
-     * @var Data
+     * @var StoreManagerInterface
      */
-    private $backendHelper;
+    private $storeManager;
 
     /**
      * @var IntegrationServiceInterface
@@ -48,7 +48,7 @@ class Setup extends Template
      * @param IntegrationCollectionFactory $collectionFactory
      * @param StoreConfig $storeConfig
      * @param EncryptorInterface $encryptor
-     * @param Data $backendHelper
+     * @param StoreManagerInterface $storeManager
      * @param IntegrationServiceInterface $integrationService
      */
     public function __construct(
@@ -56,13 +56,13 @@ class Setup extends Template
         IntegrationCollectionFactory $collectionFactory,
         StoreConfig $storeConfig,
         EncryptorInterface $encryptor,
-        Data $backendHelper,
+        StoreManagerInterface $storeManager,
         IntegrationServiceInterface $integrationService
     ) {
         $this->storeConfig = $storeConfig;
         $this->collectionFactory = $collectionFactory;
         $this->encryptor = $encryptor;
-        $this->backendHelper = $backendHelper;
+        $this->storeManager = $storeManager;
         $this->integrationService = $integrationService;
         parent::__construct($context, []);
     }
@@ -80,7 +80,7 @@ class Setup extends Template
 
         return 'email=' . $this->storeConfig->getEmailAdmin()
             . '&token=' . $token
-            . '&shop_url=' . urlencode($this->backendHelper->getUrl());
+            . '&shop_url=' . urlencode($this->storeManager->getStore()->getBaseUrl());
     }
 
     /**

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -8,7 +8,7 @@
     "guzzlehttp/guzzle": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.1.0"
+    "phpunit/phpunit": ">=5.6.3"
   },
   "license": [
     "OSL-3.0",

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.0.7">
+    <module name="Doofinder_Feed" setup_version="1.0.8">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
I confirmed that `StoreManagerInterface` has been available since the initial Magento 2 releases ([reference](https://github.com/magento/magento2/commits/2.4-develop/app/code/Magento/Store/Model/StoreManagerInterface.php)).  

Additionally, `Magento\Backend\Helper\Data` is deprecated, although it’s still being used [here](https://github.com/doofinder/doofinder-magento2/blob/8a5d5ad43e40570e922aee13191ec987b6c32891/Doofinder/Feed/Helper/StoreConfig.php#L701C21-L701C43) to retrieve `DoofinderConnectUrl`. That said, I believe this URL is indeed meant to be the backend URL.  

We might consider using a different model to retrieve the backend URL instead of relying on the deprecated helper.