### PR TITLE
PLUGINRANGERS-3533 | Fix swagger

### DIFF
--- a/Doofinder/Feed/Api/Data/FetcherInterface.php
+++ b/Doofinder/Feed/Api/Data/FetcherInterface.php
@@ -19,7 +19,7 @@ interface FetcherInterface
      * Obtains the fetched result
      *
      * @param integer $productId
-     * @return array
+     * @return mixed[]
      */
     public function get(int $productId): array;
 

--- a/Doofinder/Feed/Api/ModuleDataInterface.php
+++ b/Doofinder/Feed/Api/ModuleDataInterface.php
@@ -12,7 +12,7 @@ interface ModuleDataInterface
      *
      * This data contains module's version, M2's version and the store structure.
      *
-     * @return array
+     * @return mixed[]
      */
     public function get();
 }

--- a/Doofinder/Feed/Api/SingleScriptInterface.php
+++ b/Doofinder/Feed/Api/SingleScriptInterface.php
@@ -10,7 +10,7 @@ interface SingleScriptInterface
     /**
      * Replaces the current script by the new single script.
      *
-     * @return array
+     * @return string[]
      */
     public function replace();
 }

--- a/Doofinder/Feed/ApiClient/Client.php
+++ b/Doofinder/Feed/ApiClient/Client.php
@@ -301,7 +301,7 @@ class Client
 
     /**
      * @param array $ids
-     * @return array
+     * @return mixed[]
      */
     private function flattenArray(array $ids): array
     {

--- a/Doofinder/Feed/ApiClient/ManagementClient.php
+++ b/Doofinder/Feed/ApiClient/ManagementClient.php
@@ -41,7 +41,7 @@ class ManagementClient
      *
      * @see https://docs.doofinder.com/api/management/v2/#operation/search_engine_list
      *
-     * @return array
+     * @return mixed[]
      * @throws BadRequest
      * @throws IndexingInProgress
      * @throws NotAllowed
@@ -63,7 +63,7 @@ class ManagementClient
      * Creates the store structure in Doofinder
      *
      * @param array $storeData
-     * @return array
+     * @return mixed[]
      */
     public function createStore(array $storeData): array
     {
@@ -78,7 +78,7 @@ class ManagementClient
      * @see https://docs.doofinder.com/api/management/v2/#operation/search_engine_create
      *
      * @param array $searchEngine
-     * @return array
+     * @return mixed[]
      * @throws BadRequest
      * @throws IndexingInProgress
      * @throws NotAllowed
@@ -103,7 +103,7 @@ class ManagementClient
      *
      * @param string $hashId
      * @param string|null $callbackUrl
-     * @return array
+     * @return mixed[]
      * @throws BadRequest
      * @throws IndexingInProgress
      * @throws NotAllowed
@@ -128,7 +128,7 @@ class ManagementClient
      * @see https://docs.doofinder.com/api/management/v2/#operation/search_engine_show
      *
      * @param string $hashId
-     * @return array
+     * @return mixed[]
      * @throws BadRequest
      * @throws IndexingInProgress
      * @throws NotAllowed

--- a/Doofinder/Feed/Block/Adminhtml/Form/Field/CustomAttributes.php
+++ b/Doofinder/Feed/Block/Adminhtml/Form/Field/CustomAttributes.php
@@ -54,7 +54,7 @@ class CustomAttributes extends AbstractFieldArray
      *
      * Each row will be instance of \Magento\Framework\DataObject
      *
-     * @return array
+     * @return mixed[]
      */
     public function getArrayRows()
     {

--- a/Doofinder/Feed/Block/Adminhtml/SearchEngines/ProcessStatus.php
+++ b/Doofinder/Feed/Block/Adminhtml/SearchEngines/ProcessStatus.php
@@ -25,7 +25,7 @@ class ProcessStatus extends Template
     /**
      * Get Search Engines Process Task Status
      *
-     * @return array
+     * @return mixed[]
      */
     public function getSearchEnginesProcessStatus(): array
     {

--- a/Doofinder/Feed/Controller/Setup/ProcessCallback.php
+++ b/Doofinder/Feed/Controller/Setup/ProcessCallback.php
@@ -106,7 +106,7 @@ class ProcessCallback extends Action implements CsrfAwareActionInterface, HttpPo
      *
      * @param array $processCallbackStatus
      *
-     * @return array
+     * @return mixed[]
      */
     private function sanitizeResponse(array $processCallbackStatus): array
     {

--- a/Doofinder/Feed/Helper/Indexation.php
+++ b/Doofinder/Feed/Helper/Indexation.php
@@ -27,7 +27,7 @@ class Indexation extends AbstractHelper
      * Sanitize and prevent undefined index errors
      *
      * @param array $processTaskStatus
-     * @return array
+     * @return mixed[]
      */
     public function sanitizeProcessTaskStatus(array $processTaskStatus): array
     {

--- a/Doofinder/Feed/Helper/Inventory.php
+++ b/Doofinder/Feed/Helper/Inventory.php
@@ -106,7 +106,7 @@ class Inventory extends AbstractHelper
      * @param ProductModel $product
      * @param int|null $stockId
      *
-     * @return array
+     * @return mixed[]
      */
     private function getQuantityAndStockStatusWithMSI(ProductModel $product, ?int $stockId = null)
     {
@@ -179,7 +179,7 @@ class Inventory extends AbstractHelper
      * @param string $sku
      * @param int|null $stockId
      *
-     * @return array
+     * @return mixed[]
      */
     private function getStockItemData(string $sku, ?int $stockId = null)
     {
@@ -199,7 +199,7 @@ class Inventory extends AbstractHelper
      *
      * @param ProductModel $product
      *
-     * @return array
+     * @return mixed[]
      */
     private function getQuantityAndStockStatusWithoutMSI(ProductModel $product)
     {

--- a/Doofinder/Feed/Helper/Item.php
+++ b/Doofinder/Feed/Helper/Item.php
@@ -128,7 +128,7 @@ class Item extends AbstractHelper
      * Get search engine from store
      *
      * @param StoreInterface $store
-     * @return array
+     * @return mixed[]
      * @throws NoSuchEntityException
      * @throws NotFound
      */

--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -293,7 +293,7 @@ class Product extends AbstractHelper
      * @param array $catTree
      * @param boolean $fromNavigation
      *
-     * @return array
+     * @return mixed[]
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     private function filterCategories(array $catTree, ?bool $fromNavigation = false): array
@@ -469,7 +469,7 @@ class Product extends AbstractHelper
      *
      * @param ProductModel $product
      * @param string $attributeCode
-     * @return array|null
+     * @return mixed[]|null
      */
     public function getAttributeArray(ProductModel $product, string $attributeCode): ?array
     {

--- a/Doofinder/Feed/Helper/SearchEngine.php
+++ b/Doofinder/Feed/Helper/SearchEngine.php
@@ -78,7 +78,7 @@ class SearchEngine extends AbstractHelper
      *
      * @see https://docs.doofinder.com/api/management/v2/#operation/search_engine_list
      *
-     * @return array
+     * @return mixed[]
      * @throws BadRequest
      * @throws IndexingInProgress
      * @throws NotAllowed
@@ -105,7 +105,7 @@ class SearchEngine extends AbstractHelper
      * @see https://docs.doofinder.com/api/management/v2/#operation/search_engine_list
      *
      * @param array $searchEngine
-     * @return array
+     * @return mixed[]
      * @throws BadRequest
      * @throws IndexingInProgress
      * @throws NotAllowed
@@ -133,7 +133,7 @@ class SearchEngine extends AbstractHelper
      *
      * @param string $hashId
      * @param string|null $callbackUrl
-     * @return array
+     * @return mixed[]
      * @throws BadRequest
      * @throws IndexingInProgress
      * @throws NotAllowed
@@ -158,7 +158,7 @@ class SearchEngine extends AbstractHelper
      * Get search engine by hashid
      *
      * @param string|null $hashId
-     * @return array|null
+     * @return mixed[]|null
      * @throws NoSuchEntityException
      */
     public function getSearchEngine(string $hashId): ?array
@@ -174,7 +174,7 @@ class SearchEngine extends AbstractHelper
      * Get search engine by store code
      *
      * @param StoreInterface $store
-     * @return array|null
+     * @return mixed[]|null
      * @throws NoSuchEntityException
      */
     public function getSearchEngineByStore(StoreInterface $store): ?array

--- a/Doofinder/Feed/Helper/StoreConfig.php
+++ b/Doofinder/Feed/Helper/StoreConfig.php
@@ -218,7 +218,7 @@ class StoreConfig extends AbstractHelper
      * Creates the store in doofinder's structure
      *
      * @param array $storeData
-     * @return array
+     * @return mixed[]
      */
     public function createStore(array $storeData): array
     {
@@ -277,7 +277,7 @@ class StoreConfig extends AbstractHelper
     /**
      * Function to get the actual scope based on the request parameter
      *
-     * @return array
+     * @return mixed[]
      */
     public function getCurrentScope(): array
     {
@@ -819,7 +819,7 @@ class StoreConfig extends AbstractHelper
      * Gets Doofinder attributes to be merged later
      *
      * @param int|null $storeId
-     * @return array
+     * @return mixed[]
      */
     public function getDoofinderAttributes(?int $storeId = null): array
     {
@@ -861,7 +861,7 @@ class StoreConfig extends AbstractHelper
      *
      * @param int|null $id
      * @param string|null $scope
-     * @return Array
+     * @return mixed[]
      */
     public function getCustomAttributes(?int $id = null, ?string $scope = ScopeInterface::SCOPE_STORES): array
     {
@@ -999,7 +999,7 @@ class StoreConfig extends AbstractHelper
      * Get stores by store_group id
      *
      * @param int $storeGroupId
-     * @return array
+     * @return mixed[]
      */
     private function getStoreByGroupId($storeGroupId)
     {

--- a/Doofinder/Feed/Model/ChangedItem/ItemType.php
+++ b/Doofinder/Feed/Model/ChangedItem/ItemType.php
@@ -17,7 +17,7 @@ abstract class ItemType
     /**
      * Gets an associative array for using multiindexes' indices
      *
-     * @return array
+     * @return string[]
      */
     public static function getList()
     {

--- a/Doofinder/Feed/Model/Config/Indexer/Attributes.php
+++ b/Doofinder/Feed/Model/Config/Indexer/Attributes.php
@@ -46,7 +46,7 @@ class Attributes
      * Gets the result of merging every type of attribute
      *
      * @param integer $storeId
-     * @return array
+     * @return mixed[]
      */
     public function get(int $storeId): array
     {
@@ -59,7 +59,7 @@ class Attributes
     /**
      *  Gets the default attributes
      *
-     * @return array
+     * @return mixed[]
      */
     public function getDefaultAttributes(): array
     {
@@ -70,7 +70,7 @@ class Attributes
      * Obtains Doofinder attributes
      *
      * @param int|null $storeId
-     * @return array
+     * @return mixed[]
      */
     private function getDoofinderAttributes(?int $storeId = null): array
     {
@@ -81,7 +81,7 @@ class Attributes
      * Obtains the custom attributes wanted to be synchronized
      *
      * @param int|null $storeId
-     * @return array
+     * @return mixed[]
      */
     private function getCustomAttributes(?int $storeId = null): array
     {

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -489,7 +489,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      * reduced set of category data (only id, name, and parent id) to minimize payload size.
      *
      * @param array $categories List of categories as arrays or objects implementing getCategoryId().
-     * @return array[] Array of simplified category data with keys: category_id, entity_id, name, parent_id.
+     * @return mixed[] Array of simplified category data with keys: category_id, entity_id, name, parent_id.
      */
     private function getCategoriesInformation($categories)
     {
@@ -554,7 +554,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      * @param \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute[]|null $configurableProductsOptions
      *        Array of configurable product option objects or null.
      *
-     * @return array[] Each array contains:
+     * @return mixed[] Each array contains:
      *                 - attribute_id: int
      *                 - label: string
      *                 - code: string (attribute code)

--- a/Doofinder/Feed/Model/SingleScript.php
+++ b/Doofinder/Feed/Model/SingleScript.php
@@ -87,7 +87,7 @@ class SingleScript
     /**
      * Replaces the existing script tag with the updated Doofinder script tag.
      *
-     * @return array Returns an array containing the updated script tag as a JSON-encoded string.
+     * @return string[] Returns an array containing the updated script tag as a JSON-encoded string.
      */
     public function replace()
     {

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.0.9">
+    <module name="Doofinder_Feed" setup_version="1.0.10">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3533

Don't be afraid about the 20 files changes. The PR is just 39 lines :smile: 

Swagger can be accessed from Magento by adding /swagger to the URL. It seems that swagger does not support `array` as a return type, so instead of putting `array`, something like `string[]`, `int[]` or `mixed[]` should be used instead. It's also important to use fully qualified classnames instead of aliases (ej: `MyNamespace\MyClass` instead of just `MyClass`) in the `@return`

![image](https://github.com/user-attachments/assets/b587edf8-f89a-4e92-8e50-f6991638bfcb)
