### PR TITLE
PLUGINRANGERS-285 | Restored required function to pass the validation, avoided empty function too

### DIFF
--- a/Doofinder/Feed/Model/ResourceModel/Index.php
+++ b/Doofinder/Feed/Model/ResourceModel/Index.php
@@ -46,4 +46,14 @@ class Index extends AbstractDb
         $this->tableResolver = $tableResolver;
         $this->dimensionCollectionFactory = $dimensionCollectionFactory;
     }
+
+    /**
+     * Implementation of abstract construct.
+     *
+     * DO NOT REMOVE since it's required
+     */
+    protected function _construct()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3533
- https://github.com/doofinder/doofinder-magento2/issues/285

The function was initially removed, but since it's required it has been restored.

Since it's a fix to pass the validation, version bump is not required.