### PR TITLE
fix bin/magento setup:di:compile on magento2.4.8 with php8.4

### DIFF
--- a/Doofinder/Feed/Model/Config/Backend/ScopeGroupValue.php
+++ b/Doofinder/Feed/Model/Config/Backend/ScopeGroupValue.php
@@ -51,8 +51,8 @@ class ScopeGroupValue extends Value
         Registry $registry,
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->_storeConfig = $storeConfig;


### PR DESCRIPTION
I got the following error when I fresh installed magento2.4.8 with php8.4:

Deprecated Functionality: Doofinder\Feed\Model\Config\Backend\ScopeGroupValue::__construct(): Implicitly marking parameter $resource as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/sa  
  mpledata248/vendor/doofinder/doofinder-magento2/Doofinder/Feed/Model/Config/Backend/ScopeGroupValue.php on line 47
  
  this pull request comes to fix it                                                                                                       
                                             