### PR TITLE
Support for single store mode

### DIFF
--- a/Doofinder/Feed/Block/Adminhtml/System/Config/StoreViewTable.php
+++ b/Doofinder/Feed/Block/Adminhtml/System/Config/StoreViewTable.php
@@ -106,6 +106,18 @@ class StoreViewTable extends Field
     }
 
     /**
+     * Retrieve the integration ID.
+     *
+     * @return string|null
+     */
+    public function getIntegrationId()
+    {
+        return $this->storeConfig->getValueFromConfig(
+            StoreConfig::INTEGRATION_ID_CONFIG
+        );
+    }
+
+    /**
      * Generate the AJAX URL for sync/migrate call.
      *
      * @return string
@@ -113,5 +125,15 @@ class StoreViewTable extends Field
     public function getAjaxUrl()
     {
         return $this->getUrl("doofinderfeed/integration/createStore");
+    }
+
+    /**
+     * Generate the initial setup URL.
+     *
+     * @return string
+     */
+    public function getInitialSetupUrl()
+    {
+        return $this->getUrl("doofinderfeed/setup/index");
     }
 }

--- a/Doofinder/Feed/Block/System/Config/CreateSearchEngine.php
+++ b/Doofinder/Feed/Block/System/Config/CreateSearchEngine.php
@@ -2,6 +2,7 @@
 
 namespace Doofinder\Feed\Block\System\Config;
 
+use Doofinder\Feed\Helper\StoreConfig;
 use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Backend\Block\Template\Context;
 use Magento\Framework\Data\Form\Element\AbstractElement;
@@ -13,6 +14,27 @@ class CreateSearchEngine extends Field
      * @var string
      */
     protected $_template = 'Doofinder_Feed::System/Config/createSearchEngine.phtml';
+
+    /**
+     * @var StoreConfig
+     */
+    protected $storeConfig;
+
+    /**
+     * StoreViewTable constructor.
+     *
+     * @param Context $context
+     * @param StoreConfig $storeConfig
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        StoreConfig $storeConfig,
+        array $data = []
+    ) {
+        $this->storeConfig = $storeConfig;
+        parent::__construct($context, $data);
+    }
 
     /**
      * @inheritDoc
@@ -44,8 +66,21 @@ class CreateSearchEngine extends Field
         $button = $this->getLayout()->createBlock(\Magento\Backend\Block\Widget\Button::class)->setData([
             'id' => 'create_search_engine',
             'label' => __('Create Search Engine'),
+            'disabled' => null === $this->getIntegrationId() ? 'disabled' : '',
         ]);
         return $button->toHtml();
+    }
+
+    /**
+     * Retrieve the integration ID.
+     *
+     * @return string|null
+     */
+    public function getIntegrationId()
+    {
+        return $this->storeConfig->getValueFromConfig(
+            StoreConfig::INTEGRATION_ID_CONFIG
+        );
     }
 
     /**

--- a/Doofinder/Feed/Controller/Adminhtml/Integration/CreateStore.php
+++ b/Doofinder/Feed/Controller/Adminhtml/Integration/CreateStore.php
@@ -67,6 +67,10 @@ class CreateStore extends Action
 
         try {
             $groupId = (int)$this->getRequest()->getParam('group');
+            if (!$groupId) {
+                $defaultWebsite = $this->storeManager->getDefaultStoreView()->getWebsite();
+                $groupId = $defaultWebsite->getDefaultGroupId();
+            }
             $group = $this->storeManager->getGroup($groupId);
             $result = $this->installationService->generateDoofinderStore($group);
 

--- a/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
+++ b/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
@@ -11,7 +11,7 @@ $groups = $block->getGroups();
 $integrationId = $block->getIntegrationId();
 ?>
 <?php if ($integrationId === null): ?>
-    <?= __('It seems that you have not configured the Doofinder integration yet. Please <a href="%1"> run the initial setup</a> to configure the integration.', $escaper->escapeUrl($block->getInitialSetupUrl())) ?>
+    <?= $escaper->escapeHtml(__('It seems that you have not configured the Doofinder integration yet. Please <a href="%1"> run the initial setup</a> to configure the integration.', $block->getInitialSetupUrl()), ['a']) ?>
 <?php else: ?>
     <table class="data-grid store-table">
         <thead>

--- a/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
+++ b/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
@@ -11,7 +11,11 @@ $groups = $block->getGroups();
 $integrationId = $block->getIntegrationId();
 ?>
 <?php if ($integrationId === null): ?>
-    <?= $escaper->escapeHtml(__('It seems that you have not configured the Doofinder integration yet. Please <a href="%1"> run the initial setup</a> to configure the integration.', $block->getInitialSetupUrl()), ['a']) ?>
+    <?= $escaper->escapeHtml(__(
+        'It seems that you have not configured the Doofinder integration yet. Please '
+            . ' <a href="%1"> run the initial setup</a> to configure the integration.',
+        $block->getInitialSetupUrl()
+    ), ['a']) ?>
 <?php else: ?>
     <table class="data-grid store-table">
         <thead>

--- a/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
+++ b/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
@@ -39,7 +39,7 @@ $integrationId = $block->getIntegrationId();
                             <?= $escaper->escapeHtml($installationId  ?: __('Not installed')) ?>
                         </span>
                     </td>
-                    <td style=" text-align:center;">
+                    <td style="text-align:center;">
                         <?php if ($installationId === null): ?>
                             <button name="doofinder-create-store" type="button"
                                 onclick="doofinderSyncStore(<?= $escaper->escapeHtml($group->getId()) ?>)">

--- a/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
+++ b/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
@@ -23,10 +23,6 @@ $integrationId = $block->getIntegrationId();
         <tbody>
             <?php $evenStyle = true; ?>
             <?php foreach ($groups as $group): ?>
-                <button name="doofinder-create-store" type="button"
-                    onclick="doofinderSyncStore(<?= $escaper->escapeHtml($group->getId()) ?>)">
-                    <?= $escaper->escapeHtml(__('Create')) ?>
-                </button>
                 <?php
                 // Retrieve the installation id for the store configuration
                 $installationId = $block->getInstallationId($group);

--- a/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
+++ b/Doofinder/Feed/view/adminhtml/templates/System/Config/storeViewTable.phtml
@@ -8,84 +8,114 @@ use Magento\Store\Api\Data\GroupInterface;
 
 $escaper = $block->getEscaper();
 $groups = $block->getGroups();
+$integrationId = $block->getIntegrationId();
 ?>
-<table class="data-grid store-table">
-    <thead>
-        <tr>
-            <th class="data-grid-th no-link col-name"><?= $escaper->escapeHtml(__('Store Name')) ?></th>
-            <th class="data-grid-th last no-link col-action"><?= $escaper->escapeHtml(__('Action')) ?></th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php $evenStyle = true; ?>
-        <?php foreach ($groups as $group): ?>
-            <?php
-            // Retrieve the installation id for the store configuration
-            $installationId = $block->getInstallationId($group);
-            ?>
-            <tr class="<?= ($evenStyle = !$evenStyle) ? "even" : "" ?>"
-                id="store-view-installation-<?= $escaper->escapeHtml($group->getId()) ?>">
-                <td>
-                    <?= $escaper->escapeHtml($group->getName()); ?><br />
-                    <span class="installation-id">
-                        <?= $escaper->escapeHtml($installationId  ?: __('Not installed')) ?>
-                    </span>
-                </td>
-                <td style=" text-align:center;">
-                    <?php if ($installationId === null): ?>
-                        <button name="doofinder-create-store" type="button"
-                            onclick="doofinderSyncStore(<?= $escaper->escapeHtml($group->getId()) ?>)">
-                            <?= $escaper->escapeHtml(__('Create')) ?>
-                        </button>
-                    <?php else: ?>
-                        <button name="doofinder-create-store" type="button" disabled="disabled">
-                            <?= $escaper->escapeHtml(__('Created')) ?>
-                        </button>
-                    <?php endif; ?>
-                </td>
+<?php if ($integrationId === null): ?>
+    <?= __('It seems that you have not configured the Doofinder integration yet. Please <a href="%1"> run the initial setup</a> to configure the integration.', $escaper->escapeUrl($block->getInitialSetupUrl())) ?>
+<?php else: ?>
+    <table class="data-grid store-table">
+        <thead>
+            <tr>
+                <th class="data-grid-th no-link col-name"><?= $escaper->escapeHtml(__('Store Name')) ?></th>
+                <th class="data-grid-th last no-link col-action"><?= $escaper->escapeHtml(__('Action')) ?></th>
             </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+            <?php $evenStyle = true; ?>
+            <?php foreach ($groups as $group): ?>
+                <button name="doofinder-create-store" type="button"
+                    onclick="doofinderSyncStore(<?= $escaper->escapeHtml($group->getId()) ?>)">
+                    <?= $escaper->escapeHtml(__('Create')) ?>
+                </button>
+                <?php
+                // Retrieve the installation id for the store configuration
+                $installationId = $block->getInstallationId($group);
+                ?>
+                <tr class="<?= ($evenStyle = !$evenStyle) ? "even" : "" ?>"
+                    id="store-view-installation-<?= $escaper->escapeHtml($group->getId()) ?>">
+                    <td>
+                        <?= $escaper->escapeHtml($group->getName()); ?><br />
+                        <span class="installation-id">
+                            <?= $escaper->escapeHtml($installationId  ?: __('Not installed')) ?>
+                        </span>
+                    </td>
+                    <td style=" text-align:center;">
+                        <?php if ($installationId === null): ?>
+                            <button name="doofinder-create-store" type="button"
+                                onclick="doofinderSyncStore(<?= $escaper->escapeHtml($group->getId()) ?>)">
+                                <?= $escaper->escapeHtml(__('Create')) ?>
+                            </button>
+                        <?php else: ?>
+                            <button name="doofinder-create-store" type="button" disabled="disabled">
+                                <?= $escaper->escapeHtml(__('Created')) ?>
+                            </button>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
 
-<script>
-    require(['jquery', 'mage/translate'], function($, _t) {
+    <script>
+        require(['jquery', 'mage/translate'], function($, _t) {
 
-        window.doofinderSyncStore = function(groupId) {
-            new Ajax.Request('<?= $escaper->escapeUrl($block->getAjaxUrl()) ?>', {
-                parameters: {
-                    group: groupId
-                },
-                loaderArea: true,
-                asynchronous: true,
-                onSuccess: function(transport) {
-                    if (transport?.responseJSON?.success) {
-                        var groupSelector = '#store-view-installation-' + groupId;
-                        var buttonSelector = groupSelector + ' button[name="doofinder-create-store"]';
-                        $(`${groupSelector} .installation-id`).html(transport.responseJSON?.data.id);
-                        $(`${groupSelector}  button[name="doofinder-create-store"]`).attr('disabled', 'disabled');
-                        $(`${groupSelector} button[name="doofinder-create-store"]`).html(_t('Created'));
-                        $('body').notification('clear')
-                        $('body').notification('add', {
-                            message: _t("Doofinder Store created successfully!"),
-                            error: false,
+            window.doofinderSyncStore = function(groupId) {
+                new Ajax.Request('<?= $escaper->escapeUrl($block->getAjaxUrl()) ?>', {
+                    parameters: {
+                        group: groupId
+                    },
+                    loaderArea: true,
+                    asynchronous: true,
+                    onSuccess: function(transport) {
+                        if (transport?.responseJSON?.success) {
+                            var groupSelector = '#store-view-installation-' + groupId;
+                            var buttonSelector = groupSelector + ' button[name="doofinder-create-store"]';
+                            $(`${groupSelector} .installation-id`).html(transport.responseJSON?.data.id);
+                            $(`${groupSelector}  button[name="doofinder-create-store"]`).attr('disabled', 'disabled');
+                            $(`${groupSelector} button[name="doofinder-create-store"]`).html(_t('Created'));
+                            $('body').notification('clear')
+                            $('body').notification('add', {
+                                message: _t("Doofinder Store created successfully!"),
+                                error: false,
 
-                            /**
-                             * @param {String} message
-                             */
-                            insertMethod: function(message) {
-                                var $wrapper = $('<div></div>').html(message);
+                                /**
+                                 * @param {String} message
+                                 */
+                                insertMethod: function(message) {
+                                    var $wrapper = $('<div></div>').html(message);
 
-                                $('.page-main-actions').after($wrapper);
-                            }
-                        });
-                    } else {
+                                    $('.page-main-actions').after($wrapper);
+                                }
+                            });
+                        } else {
+                            $('body').notification('clear')
+                            $('body').notification('add', {
+                                error: true,
+                                message: _t(transport?.responseJSON?.message ||
+                                    "An unknown error has occurred while creating the store. \
+                                        Please take a look into the logs for more information."),
+
+                                /**
+                                 * @param {String} message
+                                 */
+                                insertMethod: function(message) {
+                                    var $wrapper = $('<div></div>').html(message);
+
+                                    $('.page-main-actions').after($wrapper);
+                                }
+                            });
+                            return;
+                        }
+
+                    },
+                    onFailure: function(transport) {
                         $('body').notification('clear')
                         $('body').notification('add', {
                             error: true,
                             message: _t(transport?.responseJSON?.message ||
-                                "An unknown error has occurred while creating the store. \
-                                    Please take a look into the logs for more information."),
+                                "An unknown error has occurred while creating the \
+                                search engine. Please take a look into the logs for \
+                                more information."),
 
                             /**
                              * @param {String} message
@@ -96,30 +126,9 @@ $groups = $block->getGroups();
                                 $('.page-main-actions').after($wrapper);
                             }
                         });
-                        return;
                     }
-
-                },
-                onFailure: function(transport) {
-                    $('body').notification('clear')
-                    $('body').notification('add', {
-                        error: true,
-                        message: _t(transport?.responseJSON?.message ||
-                            "An unknown error has occurred while creating the \
-                             search engine. Please take a look into the logs for \
-                             more information."),
-
-                        /**
-                         * @param {String} message
-                         */
-                        insertMethod: function(message) {
-                            var $wrapper = $('<div></div>').html(message);
-
-                            $('.page-main-actions').after($wrapper);
-                        }
-                    });
-                }
-            });
-        }
-    });
-</script>
+                });
+            }
+        });
+    </script>
+<?php endif; ?>


### PR DESCRIPTION
- **Add info to the user when no integration exists to prevent action failures.**
- **Fix store creation when Magento is in single store mode**

In single store mode, the admin is simplified so scopes are hidden. Then the configuration form looks like this:

![image](https://github.com/user-attachments/assets/67111664-01e9-4bdb-a981-7b7a5d7046f1)

In this PR we show to the user clearer messages and prevent actions that can throws errors or confuse the user.

![Screenshot from 2025-05-19 20-17-56](https://github.com/user-attachments/assets/a4cd109b-cf83-45cc-a6a8-65d04fa6777a)

![Screenshot from 2025-05-19 20-17-34](https://github.com/user-attachments/assets/5bc4c429-8d79-46da-adbb-9f639b740876)
