### PR TITLE
PLUGINRANGERS-366 | Solved incorrect URL handling in product redirects

### DIFF
--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -162,6 +162,7 @@ class Product extends AbstractHelper
             UrlRewrite::ENTITY_ID => $productId,
             UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
             UrlRewrite::STORE_ID => $storeId,
+            UrlRewrite::REDIRECT_TYPE => 0,
         ];
         $rewrite = $this->urlFinder->findOneByData($filterData);
         if ($rewrite) {

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.2.0">
+    <module name="Doofinder_Feed" setup_version="1.2.1">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-magento2/issues/366

I have added -new at the end of the URL of a product and the results are:

Without the fix:

![Image](https://github.com/user-attachments/assets/0592537a-9070-4c06-aa58-a4d1c37348ad)

With the fix:

![Image](https://github.com/user-attachments/assets/c0b9e53c-8045-40ec-b641-3060266e93ac)