### PR TITLE
PLUGINRANGERS-3965 | Excluded files via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+docker-compose.elasticsearch.yml     export-ignore
+docker-compose.opensearch.yml        export-ignore
+docker-compose.yml                   export-ignore
+docker/                              export-ignore
+Makefile                             export-ignore
+default.vcl                          export-ignore
+.gitignore                           export-ignore
+.gitattributes                       export-ignore
+.editorconfig                        export-ignore
+.vscode/                             export-ignore
+.github/                             export-ignore


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3965

Related PR:

- https://github.com/doofinder/doofinder-magento2/pull/419

Version bump should not be required here.