### PR TITLE
PLUGINRANGERS-3949 | Avoid price 0 in extension attributes

### DIFF
--- a/Doofinder/Feed/Helper/Price.php
+++ b/Doofinder/Feed/Helper/Price.php
@@ -98,7 +98,7 @@ class Price extends AbstractHelper
      * Gets the price applying the taxes in case it's necessary
      *
      * @param \Magento\Catalog\Model\Product $product
-     * @param mixed $price
+     * @param \Magento\Framework\Pricing\Render\Amount|null $price
      * @return int|float
      */
     private function getPriceApplyingCorrespondingTaxes($product, $price)
@@ -111,6 +111,10 @@ class Price extends AbstractHelper
         $this->getTaxEnabled() ?
             $calculatedPrice = $this->getPriceWithTaxes($product, $amount):
             $calculatedPrice = $amount->getBaseAmount();
+
+        if (0 === (int)$calculatedPrice) {
+            $calculatedPrice = $amount->getValue();
+        }
 
         return (float)$calculatedPrice;
     }

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.3.2">
+    <module name="Doofinder_Feed" setup_version="1.3.3">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3949

For some unknown reasons, getBaseAmount() might return a float 0. For example, it's happening for the customer in the related issue. This should prevent this scenario, but we were unable to detect why is returning 0.