### PR TITLE
Set prerelease flag on release creation workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -25,3 +25,4 @@ jobs:
           files: ${{ steps.vars.outputs.zip_path }}
           name: Doofinder for Magento 2 - ${{ steps.vars.outputs.tag }}
           generate_release_notes: true
+          prerelease: true


### PR DESCRIPTION
[Nuestra documentación](https://github.com/doofinder/development-handbook/blob/master/guides/plugin-rangers/magento.md#publishing-the-release-in-github) señala que el workflow crea la release como `prerelease` y luego hay que marcarla manualmente como `latest`, pero en realidad sucede lo contrario.

Documentación de la action: https://github.com/softprops/action-gh-release?tab=readme-ov-file#-customizing

