### PR TITLE
Interpret price in the default display currency

### DIFF
--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -478,14 +478,14 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $store = $this->storeManager->getStore($storeId);
         $multiprice = [];
 
-        $baseCurrencyCode = $store->getBaseCurrencyCode();
+        $defaultCurrencyCode = $store->getDefaultCurrencyCode();
         $allowedCurrencies = $store->getAvailableCurrencyCodes(true);
         if (empty($allowedCurrencies)) {
             return $multiprice;
         }
 
         $currency = $this->currencyFactory->create();
-        $rates = $currency->getCurrencyRates($baseCurrencyCode, $allowedCurrencies);
+        $rates = $currency->getCurrencyRates($defaultCurrencyCode, $allowedCurrencies);
 
         foreach ($allowedCurrencies as $currencyCode) {
             $rate = isset($rates[$currencyCode]) ? $rates[$currencyCode] : 1;

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.3.7">
+    <module name="Doofinder_Feed" setup_version="1.3.8">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Fixes https://github.com/doofinder/support/issues/4473

“Price” and “Special Price” were incorrectly interpreted as being in the base currency instead of the default display currency, leading to incorrect multiprice conversions whenever those currencies differed.