### PR TITLE
Solve issue with csp policy

### DIFF
--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/csp_whitelist.xml
+++ b/Doofinder/Feed/etc/csp_whitelist.xml
@@ -15,12 +15,12 @@
         </policy>
         <policy id="script-src">
             <values>
-                <value id="doofinder_script" type="host">cdn.doofinder.com</value>
+                <value id="doofinder_script" type="host">*.doofinder.com</value>
             </values>
         </policy>
         <policy id="img-src">
             <values>
-                <value id="doofinder_img" type="host">cdn.doofinder.com</value>
+                <value id="doofinder_img" type="host">*.doofinder.com</value>
             </values>
         </policy>
     </policies>

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.3.11">
+    <module name="Doofinder_Feed" setup_version="1.3.12">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/4535

Tenemos un cliente al que no le carga la capa porque solo permitimos cargas de ficheros de `cdn.doofinder.com` y no de `us1-config.doofinder.com` he cambiado el csp para que acepte de cualquier subdominio de doofinder.