### PR TITLE
PLUGINRANGERS-4872 | Prevented error on categories if url_path is not set

### DIFF
--- a/Doofinder/Feed/Model/CategoryListRepository.php
+++ b/Doofinder/Feed/Model/CategoryListRepository.php
@@ -94,14 +94,18 @@ class CategoryListRepository implements \Magento\Catalog\Api\CategoryListInterfa
     {
         $searchResult =  $this->categoryRepository->getList($searchCriteria);
         $baseUrl = $this->storeManager->getStore()->getBaseUrl();
-        $category_url_suffix = $this->scopeConfig->getValue(
+        $categoryUrlSuffix = $this->scopeConfig->getValue(
             'catalog/seo/category_url_suffix',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
 
         foreach ($searchResult->getItems() as $category) {
             $categoryData = $category->getData();
-            $fullPath = $baseUrl . $categoryData['url_path'] . $category_url_suffix;
+            $urlPath = $categoryData['url_path'] ?? '';
+            if ($categoryUrlSuffix && substr($urlPath, -strlen($categoryUrlSuffix)) != $categoryUrlSuffix) {
+                $urlPath .= $categoryUrlSuffix;
+            }
+            $fullPath = $baseUrl . $urlPath;
             $extensionAttributes = $category->getExtensionAttributes();
             $extensionAttributes->setUrlFull($fullPath);
         }

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.6.0">
+    <module name="Doofinder_Feed" setup_version="1.6.1">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/4872

Fix based on: https://github.com/doofinder/doofinder-magento2/blob/2f6955b2bc2d3a9407a2c288ee297ddd291ee74c/Doofinder/Feed/Model/ProductRepository.php#L781