### PR TITLE
feat: expose dfPlatform variable for Magento 2

### DIFF
--- a/Doofinder/Feed/view/frontend/templates/display/layer.phtml
+++ b/Doofinder/Feed/view/frontend/templates/display/layer.phtml
@@ -3,5 +3,6 @@
     var dfPageType = <?= /* @noEscape */ json_encode($block->getPageType()) ?>;
     var dfProductId = <?= /* @noEscape */ json_encode($block->getDfProductId()) ?>;
     var dfCategoryName = <?= /* @noEscape */ json_encode($block->getDfCategoryName()) ?>;
+    var dfPlatform = 'magento2';
 </script>
 <?= /* @noEscape */ $block->getDisplayLayer(); ?>


### PR DESCRIPTION
## Summary
- Adds `var dfPlatform = 'magento2'` alongside existing df* variables in `layer.phtml`
- Value matches doomanager's store `platform` field
- Allows apps-loader to map plugin values to Doofinder's standardized platform identifiers

## Related
- doofinder/dooplugins#2225

## Test plan
- [ ] Verify `window.dfPlatform === 'magento2'` on a Magento 2 storefront

🤖 Generated with [Claude Code](https://claude.com/claude-code)