### PR TITLE
Save only `enabled` attributes to db

### DIFF
--- a/Doofinder/Feed/Model/Config/Backend/CustomAttributes.php
+++ b/Doofinder/Feed/Model/Config/Backend/CustomAttributes.php
@@ -70,6 +70,18 @@ class CustomAttributes extends ArraySerialized implements ProcessorInterface
      */
     public function beforeSave()
     {
+        $value = $this->getValue();
+        if (is_array($value)) {
+            $this->setValue(
+                array_filter(
+                    $value,
+                    static function ($row) {
+                        return is_array($row) && !empty($row['enabled']);
+                    }
+                )
+            );
+        }
+
         $this->messageManager->addNoticeMessage(
             __('To apply the changes in the custom attributes to your feed, it will be necessary to reindex it')
         );

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.6.2">
+    <module name="Doofinder_Feed" setup_version="1.6.3">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {
@@ -67,4 +67,3 @@
     ]
   }
 }
-


### PR DESCRIPTION
Closes https://github.com/doofinder/support/issues/4868.

We were saving all attributes (selected and non-selected) into the database. This was causing problems for stores with a lot of attributes, as it was exceeding the maximum size of the database field.

This approach was suggested by a customer who did some debugging on their store after installing our plugin and experiencing problems.