### PR TITLE
Do not include categories from other store groups

### DIFF
--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -756,9 +756,13 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         // Scope category collection with current store Root category
         $storeRootPath = '1/' . $this->storeManager->getStore()->getRootCategoryId() . '/';
 
-        // Get all category Ids (with parents Ids from paths)
+        // Keep only categories that belong to the current store root tree.
         $categoryIdsWithParents = array_reduce($categoryPaths, function ($acc, $path) use ($storeRootPath) {
-            $path = str_replace($storeRootPath, '', $path);
+            if (strpos($path, $storeRootPath) !== 0) {
+                return $acc;
+            }
+
+            $path = substr($path, strlen($storeRootPath));
             $ids = explode('/', $path);
             return array_unique(array_merge($acc, $ids));
         }, []);

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.6.3">
+    <module name="Doofinder_Feed" setup_version="1.6.4">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
Closes https://github.com/doofinder/support/issues/4920.

In Magento, a category tree is configured at **Store Group** level. Store Groups map to Doofinder Stores. However, products exist or can exist at a global level and have categories from several **Store Group**s but these categories should not leak between stores. This is what this PR fixes, preventing including in the categories of the product categories from other Store Groups.