### PR TITLE
Sofia/csp nonce throwable crash

### DIFF
--- a/Doofinder/Feed/Block/Display/Layer.php
+++ b/Doofinder/Feed/Block/Display/Layer.php
@@ -183,9 +183,13 @@ class Layer extends Template
     public function getNonceAttribute(): string
     {
         if (class_exists(\Magento\Csp\Helper\CspNonceProvider::class)) {
-            $cspNonceProvider = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Csp\Helper\CspNonceProvider::class);
-            return ' nonce="' . $cspNonceProvider->generateNonce() . '"';
+            try {
+                $cspNonceProvider = \Magento\Framework\App\ObjectManager::getInstance()
+                    ->get(\Magento\Csp\Helper\CspNonceProvider::class);
+                return ' nonce="' . $cspNonceProvider->generateNonce() . '"';
+            } catch (\Throwable $e) {
+                return '';
+            }
         }
         return '';
     }

--- a/Doofinder/Feed/Helper/StoreConfig.php
+++ b/Doofinder/Feed/Helper/StoreConfig.php
@@ -583,6 +583,7 @@ class StoreConfig extends AbstractHelper
                     $nonceAttr = 'nonce="' . $nonce . '"';
                 } catch (\Throwable $e) {
                     // CspNonceProvider may not be resolvable if DI is not compiled
+                    $nonceAttr = '';
                 }
             }
 

--- a/Doofinder/Feed/Helper/StoreConfig.php
+++ b/Doofinder/Feed/Helper/StoreConfig.php
@@ -576,10 +576,14 @@ class StoreConfig extends AbstractHelper
             $nonceAttr = '';
             // To keep backwards compatibility with older versions
             if (class_exists(\Magento\Csp\Helper\CspNonceProvider::class)) {
-                $cspNonceProvider = \Magento\Framework\App\ObjectManager::getInstance()
-                    ->get(\Magento\Csp\Helper\CspNonceProvider::class);
-                $nonce = $cspNonceProvider->generateNonce();
-                $nonceAttr = 'nonce="' . $nonce . '"';
+                try {
+                    $cspNonceProvider = \Magento\Framework\App\ObjectManager::getInstance()
+                        ->get(\Magento\Csp\Helper\CspNonceProvider::class);
+                    $nonce = $cspNonceProvider->generateNonce();
+                    $nonceAttr = 'nonce="' . $nonce . '"';
+                } catch (\Throwable $e) {
+                    // CspNonceProvider may not be resolvable if DI is not compiled
+                }
             }
 
             $singleScriptAdditionalConfig = <<<EOT
@@ -595,7 +599,7 @@ class StoreConfig extends AbstractHelper
                 EOT;
 
             return $singleScriptAdditionalConfig . $singleScript;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return null;
         }
     }

--- a/Doofinder/Feed/Helper/StoreConfig.php
+++ b/Doofinder/Feed/Helper/StoreConfig.php
@@ -599,7 +599,7 @@ class StoreConfig extends AbstractHelper
                 EOT;
 
             return $singleScriptAdditionalConfig . $singleScript;
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             return null;
         }
     }

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.6.3">
+    <module name="Doofinder_Feed" setup_version="1.6.4">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/4882

Parece que el problema viene con  el csp del cliente, que parece que tiene la clase pero tiene algo roto que hace que pete, entonces parece que si capturamos la exepción y devolvemos "" en caso de que esto pete funciona bien. Creo que no habría problema realmente porque si tienen csp funciona correctamente y si no continuamos sin poner nada.