### PR TITLE
fix: Guarantee variant instance independently of `load` return

### DIFF
--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -695,8 +695,9 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         }
 
         foreach ($configurableLinksIds as $productId) {
-            $product = $this->productFactory->create()->load($productId);
-            if (!isset($product) || Status::STATUS_ENABLED !== (int) $product->getStatus()) {
+            $product = $this->getById($productId);
+
+            if (Status::STATUS_ENABLED !== (int) $product->getStatus()) {
                 continue;
             }
 

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.6.6">
+    <module name="Doofinder_Feed" setup_version="1.6.7">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
By avoiding the return value of `load()`, we avoid any problems that may come due to an interceptor plugin breaking the `load()` contract and returning `null`.

We use the base `$product` instance that gets modified by `load` instead of using the `load` return. With the previous fix, we were excluding the variants of a product in case a plugin broke the `load` contract.