### PR TITLE
fix: Use parent URL for hidden configurable children

### DIFF
--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -25,7 +25,6 @@ use Magento\Tax\Model\Config as TaxConfig;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
-use Magento\Catalog\Model\Product\Type as ProductType;
 
 /**
  * Product helper
@@ -152,11 +151,13 @@ class Product extends AbstractHelper
         $requestPath = $product->getRequestPath();
         $productId = $product->getId();
         $parents = $this->configurable->getParentIdsByChild($product->getId());
-        if ($product->getTypeId() === ProductType::TYPE_SIMPLE
-                && count($parents) > 0
-                && !in_array($product->getVisibility(), $this->visibilityAllowed)
-            ) {
-                $productId = $parents[0];
+        $hasConfigurableParent = count($parents) > 0;
+        $isVisibleIndividually = in_array($product->getVisibility(), $this->visibilityAllowed);
+        $useParentUrl = $hasConfigurableParent && !$isVisibleIndividually;
+
+        if ($useParentUrl) {
+            $productId = $parents[0];
+            $requestPath = null;
         }
         $filterData = [
             UrlRewrite::ENTITY_ID => $productId,
@@ -173,9 +174,7 @@ class Product extends AbstractHelper
         } else {
             $routePath = 'catalog/product/view';
             // In case the product is a variant we need the ID of the configurable
-            if ($product->getTypeId() === ProductType::TYPE_SIMPLE
-                && count($parents) > 0
-            ) {
+            if ($useParentUrl) {
                 $routeParams['id'] = $parents[0];
                 $routeParams['s'] = $product->getUrlKey();
             } else {

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.7.1">
+    <module name="Doofinder_Feed" setup_version="1.7.2">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
Closes https://github.com/doofinder/support/issues/4983.

Parece que, para este cliente, el producto no tiene tipo Simple, sino Downloadable. El caso es que no veo tampoco un motivo claro para exigir que el producto tenga que ser simple. Si el producto tiene padres y no es visible por sí mismo, parece tener sentido añadir como enlace el del padre en cualquier caso.