### PR TITLE
PLUGINRANGERS-348 | Removed Doofinder Script toggle references from everywhere, script is always enabled

### DIFF
--- a/Doofinder/Feed/Helper/StoreConfig.php
+++ b/Doofinder/Feed/Helper/StoreConfig.php
@@ -81,8 +81,6 @@ class StoreConfig extends AbstractHelper
      */
     public const HASH_ID_CONFIG = 'doofinder_config_config/doofinder_layer/hash_id';
 
-    public const DISPLAY_LAYER_ENABLED = 'doofinder_config_config/doofinder_layer/doofinder_layer_enabled';
-
     public const DISPLAY_LAYER_INSTALLATION_ID = 'doofinder_config_config/doofinder_layer/installation_id';
 
     /**
@@ -803,26 +801,6 @@ class StoreConfig extends AbstractHelper
     public function setInstallingLoopStatus(int $value)
     {
         $this->configWriter->save(self::INSTALLING_LOOP_STATUS, $value);
-    }
-
-    /**
-     * Get display layer enabled
-     *
-     * @return int
-     */
-    public function getDisplayLayerEnabled(): int
-    {
-        return (int)$this->getValueFromConfig(self::DISPLAY_LAYER_ENABLED);
-    }
-
-    /**
-     * Set display layer enabled
-     *
-     * @param int $value
-     */
-    public function setDisplayLayerEnabled(int $value)
-    {
-        $this->configWriter->save(self::DISPLAY_LAYER_ENABLED, $value);
     }
 
     /**

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/adminhtml/system.xml
+++ b/Doofinder/Feed/etc/adminhtml/system.xml
@@ -47,20 +47,6 @@
                    showInWebsite="1"
                    showInStore="1">
                 <label>Doofinder Script</label>
-                <field id="doofinder_layer_enabled"
-                       translate="label"
-                       type="select"
-                       sortOrder="100"
-                       showInDefault="1"
-                       showInWebsite="0"
-                       showInStore="0">
-                    <label>Enabled</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <backend_model>Magento\Framework\App\Config\Value</backend_model>
-                    <comment>
-                        <![CDATA[ Activating this option you are inserting the script into your store code. You can manage product visibility in Doofinder. ]]>
-                    </comment>
-                </field>
                 <field id="store_view_table"
                        translate="label comment"
                        type="text"

--- a/Doofinder/Feed/etc/config.xml
+++ b/Doofinder/Feed/etc/config.xml
@@ -3,9 +3,6 @@
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <doofinder_config_config>
-            <doofinder_layer>
-                <doofinder_layer_enabled>1</doofinder_layer_enabled>
-            </doofinder_layer>
             <update_on_save>
                 <cron_expression>0 0 * * *</cron_expression>
                 <image_size>&#x200B;</image_size>

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.7.2">
+    <module name="Doofinder_Feed" setup_version="1.7.3">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/Doofinder/Feed/view/frontend/layout/default.xml
+++ b/Doofinder/Feed/view/frontend/layout/default.xml
@@ -11,7 +11,6 @@
                 name="doofinderfeed_display_layer"
                 as="doofinderfeed.display.layer"
                 template="Doofinder_Feed::display/layer.phtml"
-                ifconfig="doofinder_config_config/doofinder_layer/doofinder_layer_enabled"
                 after="-"/>
         </referenceBlock>
     </body>

--- a/Doofinder/Feed/view/frontend/layout/hyva_default.xml
+++ b/Doofinder/Feed/view/frontend/layout/hyva_default.xml
@@ -14,7 +14,6 @@
                 name="doofinderfeed_display_layer"
                 as="doofinderfeed.display.layer"
                 template="Doofinder_Feed::display/layer.phtml"
-                ifconfig="doofinder_config_config/doofinder_layer/doofinder_layer_enabled"
                 after="-"/>
         </referenceBlock>
     </body>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/templates/etc/config.xml
+++ b/templates/etc/config.xml
@@ -3,9 +3,6 @@
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <doofinder_config_config>
-            <doofinder_layer>
-                <doofinder_layer_enabled>1</doofinder_layer_enabled>
-            </doofinder_layer>
             <update_on_save>
                 <cron_expression>0 0 * * *</cron_expression>
                 <image_size>&#x200B;</image_size>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-magento2/issues/348

Unlike in this one: https://github.com/doofinder/doofinder-magento2/pull/476, the approach here is to completely remove the flag, so the script is always enabled via module. It can be disabled from Doofinder admin.