### PR TITLE
fix: defend custom attribute resolution against PHP 8.1 exceptions

### DIFF
--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -414,9 +414,17 @@ class Product extends AbstractHelper
             return null;
         }
         $frontend = $attribute->getFrontend();
-        $value = $frontend->getOption($optionId);
-        if (!$value) {
-            $value = $frontend->getValue($product);
+        try {
+            $value = $frontend->getOption($optionId);
+            if (!$value) {
+                $value = $frontend->getValue($product);
+            }
+        } catch (\Throwable $e) {
+            $this->_logger->warning(
+                sprintf('Doofinder: could not resolve type for attribute "%s": %s', $attributeCode, $e->getMessage()),
+                ['product_id' => $product->getId()]
+            );
+            return null;
         }
 
         return get_debug_type($value);
@@ -441,9 +449,17 @@ class Product extends AbstractHelper
             return null;
         }
         $frontend = $attribute->getFrontend();
-        $value = $frontend->getOption($optionId);
-        if (!$value) {
-            $value = $frontend->getValue($product);
+        try {
+            $value = $frontend->getOption($optionId);
+            if (!$value) {
+                $value = $frontend->getValue($product);
+            }
+        } catch (\Throwable $e) {
+            $this->_logger->warning(
+                sprintf('Doofinder: could not resolve value for attribute "%s": %s', $attributeCode, $e->getMessage()),
+                ['product_id' => $product->getId()]
+            );
+            return null;
         }
         if (is_a($value, Phrase::class)) {
             $value = $value->render();

--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -416,15 +416,23 @@ class Product extends AbstractHelper
         $frontend = $attribute->getFrontend();
         try {
             $value = $frontend->getOption($optionId);
-            if (!$value) {
-                $value = $frontend->getValue($product);
-            }
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             $this->_logger->warning(
                 sprintf('Doofinder: could not resolve type for attribute "%s": %s', $attributeCode, $e->getMessage()),
                 ['product_id' => $product->getId()]
             );
             return null;
+        }
+        if (!$value) {
+            try {
+                $value = $frontend->getValue($product);
+            } catch (\Exception $e) {
+                $this->_logger->warning(
+                    sprintf('Doofinder: could not resolve type for attribute "%s": %s', $attributeCode, $e->getMessage()),
+                    ['product_id' => $product->getId()]
+                );
+                return null;
+            }
         }
 
         return get_debug_type($value);
@@ -451,15 +459,23 @@ class Product extends AbstractHelper
         $frontend = $attribute->getFrontend();
         try {
             $value = $frontend->getOption($optionId);
-            if (!$value) {
-                $value = $frontend->getValue($product);
-            }
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             $this->_logger->warning(
                 sprintf('Doofinder: could not resolve value for attribute "%s": %s', $attributeCode, $e->getMessage()),
                 ['product_id' => $product->getId()]
             );
             return null;
+        }
+        if (!$value) {
+            try {
+                $value = $frontend->getValue($product);
+            } catch (\Exception $e) {
+                $this->_logger->warning(
+                    sprintf('Doofinder: could not resolve value for attribute "%s": %s', $attributeCode, $e->getMessage()),
+                    ['product_id' => $product->getId()]
+                );
+                return null;
+            }
         }
         if (is_a($value, Phrase::class)) {
             $value = $value->render();

--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -418,7 +418,11 @@ class Product extends AbstractHelper
             $value = $frontend->getOption($optionId);
         } catch (\Exception $e) {
             $this->_logger->warning(
-                sprintf('Doofinder: could not resolve type for attribute "%s": %s', $attributeCode, $e->getMessage()),
+                sprintf(
+                    'Doofinder: could not resolve type for attribute "%s": %s',
+                    $attributeCode,
+                    $e->getMessage()
+                ),
                 ['product_id' => $product->getId()]
             );
             return null;
@@ -428,7 +432,11 @@ class Product extends AbstractHelper
                 $value = $frontend->getValue($product);
             } catch (\Exception $e) {
                 $this->_logger->warning(
-                    sprintf('Doofinder: could not resolve type for attribute "%s": %s', $attributeCode, $e->getMessage()),
+                    sprintf(
+                        'Doofinder: could not resolve type for attribute "%s": %s',
+                        $attributeCode,
+                        $e->getMessage()
+                    ),
                     ['product_id' => $product->getId()]
                 );
                 return null;
@@ -461,7 +469,11 @@ class Product extends AbstractHelper
             $value = $frontend->getOption($optionId);
         } catch (\Exception $e) {
             $this->_logger->warning(
-                sprintf('Doofinder: could not resolve value for attribute "%s": %s', $attributeCode, $e->getMessage()),
+                sprintf(
+                    'Doofinder: could not resolve value for attribute "%s": %s',
+                    $attributeCode,
+                    $e->getMessage()
+                ),
                 ['product_id' => $product->getId()]
             );
             return null;
@@ -471,7 +483,11 @@ class Product extends AbstractHelper
                 $value = $frontend->getValue($product);
             } catch (\Exception $e) {
                 $this->_logger->warning(
-                    sprintf('Doofinder: could not resolve value for attribute "%s": %s', $attributeCode, $e->getMessage()),
+                    sprintf(
+                        'Doofinder: could not resolve value for attribute "%s": %s',
+                        $attributeCode,
+                        $e->getMessage()
+                    ),
                     ['product_id' => $product->getId()]
                 );
                 return null;

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.7.3">
+    <module name="Doofinder_Feed" setup_version="1.7.4">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>


### PR DESCRIPTION
Fixes doofinder/support#5060

On PHP 8.1, Magento's EAV/Zend_Db internals throw deprecation exceptions when resolving certain custom attribute values (null passed to string functions), which was aborting the entire catalog indexation with a 500. Wrapped the `getOption()`/`getValue()` calls in `getAttributeType()` and `getAttribute()` in independent try/catch blocks so a single bad attribute skips gracefully and logs a warning instead of killing the run.