### PR TITLE
Use parent URL key in configurable variant URL fallback

### DIFF
--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -80,11 +80,6 @@ class Product extends AbstractHelper
     protected $configurable;
 
     /**
-     * @var ProductResourceModel
-     */
-    private $productResource;
-
-    /**
      * @see /Doofinder/Feed/Observer/Product/AbstractChangedProductObserver.php
      *
      * @var []
@@ -102,7 +97,6 @@ class Product extends AbstractHelper
      * @param EavConfig $eavConfig
      * @param Configurable $configurable
      * @param InventoryHelper $inventoryHelper
-     * @param ProductResourceModel $productResource
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -115,8 +109,7 @@ class Product extends AbstractHelper
         UrlFinderInterface $urlFinder,
         EavConfig $eavConfig,
         Configurable $configurable,
-        InventoryHelper $inventoryHelper,
-        ProductResourceModel $productResource
+        InventoryHelper $inventoryHelper
     ) {
         $this->categoryCollectionFactory = $categoryCollectionFactory;
         $this->imageHelper = $imageHelper;
@@ -127,7 +120,6 @@ class Product extends AbstractHelper
         $this->eavConfig = $eavConfig;
         $this->configurable = $configurable;
         $this->inventoryHelper = $inventoryHelper;
-        $this->productResource = $productResource;
         $this->visibilityAllowed = [Visibility::VISIBILITY_IN_SEARCH, Visibility::VISIBILITY_BOTH];
         parent::__construct($context);
     }
@@ -150,10 +142,11 @@ class Product extends AbstractHelper
      * This method is based on the \Magento\Catalog\Model\Product\Url::getUrl() method.
      *
      * @param ProductModel $product
+     * @param ProductResourceModel|null $resourceModel Used to read the parent url_key when the URL rewrite is missing.
      *
      * @return string
      */
-    public function getProductUrl(ProductModel $product): string
+    public function getProductUrl(ProductModel $product, ?ProductResourceModel $resourceModel = null): string
     {
         $storeId = $product->getStoreId();
         $routePath = '';
@@ -185,14 +178,16 @@ class Product extends AbstractHelper
             // In case the product is a variant we need the ID and url_key of the configurable
             if ($useParentUrl) {
                 $routeParams['id'] = $parents[0];
-                $parentUrlKey = $this->productResource->getAttributeRawValue(
-                    $parents[0],
-                    'url_key',
-                    $storeId
-                );
-                $routeParams['s'] = is_string($parentUrlKey) && $parentUrlKey !== ''
-                    ? $parentUrlKey
-                    : $product->getUrlKey();
+                if ($resourceModel !== null) {
+                    $parentUrlKey = $resourceModel->getAttributeRawValue(
+                        $parents[0],
+                        'url_key',
+                        $storeId
+                    );
+                    if (!empty($parentUrlKey)) {
+                        $routeParams['s'] = $parentUrlKey;
+                    }
+                }
             } else {
                 $routeParams['id'] = $product->getId();
                 $routeParams['s'] = $product->getUrlKey();

--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -80,6 +80,11 @@ class Product extends AbstractHelper
     protected $configurable;
 
     /**
+     * @var ProductResourceModel
+     */
+    private $productResource;
+
+    /**
      * @see /Doofinder/Feed/Observer/Product/AbstractChangedProductObserver.php
      *
      * @var []
@@ -97,6 +102,7 @@ class Product extends AbstractHelper
      * @param EavConfig $eavConfig
      * @param Configurable $configurable
      * @param InventoryHelper $inventoryHelper
+     * @param ProductResourceModel $productResource
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -109,7 +115,8 @@ class Product extends AbstractHelper
         UrlFinderInterface $urlFinder,
         EavConfig $eavConfig,
         Configurable $configurable,
-        InventoryHelper $inventoryHelper
+        InventoryHelper $inventoryHelper,
+        ProductResourceModel $productResource
     ) {
         $this->categoryCollectionFactory = $categoryCollectionFactory;
         $this->imageHelper = $imageHelper;
@@ -120,6 +127,7 @@ class Product extends AbstractHelper
         $this->eavConfig = $eavConfig;
         $this->configurable = $configurable;
         $this->inventoryHelper = $inventoryHelper;
+        $this->productResource = $productResource;
         $this->visibilityAllowed = [Visibility::VISIBILITY_IN_SEARCH, Visibility::VISIBILITY_BOTH];
         parent::__construct($context);
     }
@@ -142,11 +150,10 @@ class Product extends AbstractHelper
      * This method is based on the \Magento\Catalog\Model\Product\Url::getUrl() method.
      *
      * @param ProductModel $product
-     * @param ProductResourceModel|null $resourceModel Used to read the parent url_key when the URL rewrite is missing.
      *
      * @return string
      */
-    public function getProductUrl(ProductModel $product, ?ProductResourceModel $resourceModel = null): string
+    public function getProductUrl(ProductModel $product): string
     {
         $storeId = $product->getStoreId();
         $routePath = '';
@@ -178,15 +185,13 @@ class Product extends AbstractHelper
             // In case the product is a variant we need the ID and url_key of the configurable
             if ($useParentUrl) {
                 $routeParams['id'] = $parents[0];
-                if ($resourceModel !== null) {
-                    $parentUrlKey = $resourceModel->getAttributeRawValue(
-                        $parents[0],
-                        'url_key',
-                        $storeId
-                    );
-                    if (!empty($parentUrlKey)) {
-                        $routeParams['s'] = $parentUrlKey;
-                    }
+                $parentUrlKey = $this->productResource->getAttributeRawValue(
+                    $parents[0],
+                    'url_key',
+                    $storeId
+                );
+                if (!empty($parentUrlKey)) {
+                    $routeParams['s'] = $parentUrlKey;
                 }
             } else {
                 $routeParams['id'] = $product->getId();

--- a/Doofinder/Feed/Helper/Product.php
+++ b/Doofinder/Feed/Helper/Product.php
@@ -25,6 +25,7 @@ use Magento\Tax\Model\Config as TaxConfig;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResourceModel;
 
 /**
  * Product helper
@@ -79,6 +80,11 @@ class Product extends AbstractHelper
     protected $configurable;
 
     /**
+     * @var ProductResourceModel
+     */
+    private $productResource;
+
+    /**
      * @see /Doofinder/Feed/Observer/Product/AbstractChangedProductObserver.php
      *
      * @var []
@@ -96,6 +102,7 @@ class Product extends AbstractHelper
      * @param EavConfig $eavConfig
      * @param Configurable $configurable
      * @param InventoryHelper $inventoryHelper
+     * @param ProductResourceModel $productResource
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -108,7 +115,8 @@ class Product extends AbstractHelper
         UrlFinderInterface $urlFinder,
         EavConfig $eavConfig,
         Configurable $configurable,
-        InventoryHelper $inventoryHelper
+        InventoryHelper $inventoryHelper,
+        ProductResourceModel $productResource
     ) {
         $this->categoryCollectionFactory = $categoryCollectionFactory;
         $this->imageHelper = $imageHelper;
@@ -119,6 +127,7 @@ class Product extends AbstractHelper
         $this->eavConfig = $eavConfig;
         $this->configurable = $configurable;
         $this->inventoryHelper = $inventoryHelper;
+        $this->productResource = $productResource;
         $this->visibilityAllowed = [Visibility::VISIBILITY_IN_SEARCH, Visibility::VISIBILITY_BOTH];
         parent::__construct($context);
     }
@@ -173,10 +182,17 @@ class Product extends AbstractHelper
             $routeParams['_direct'] = $requestPath;
         } else {
             $routePath = 'catalog/product/view';
-            // In case the product is a variant we need the ID of the configurable
+            // In case the product is a variant we need the ID and url_key of the configurable
             if ($useParentUrl) {
                 $routeParams['id'] = $parents[0];
-                $routeParams['s'] = $product->getUrlKey();
+                $parentUrlKey = $this->productResource->getAttributeRawValue(
+                    $parents[0],
+                    'url_key',
+                    $storeId
+                );
+                $routeParams['s'] = is_string($parentUrlKey) && $parentUrlKey !== ''
+                    ? $parentUrlKey
+                    : $product->getUrlKey();
             } else {
                 $routeParams['id'] = $product->getId();
                 $routeParams['s'] = $product->getUrlKey();

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -311,7 +311,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      */
     private function getProductUrl(Product $product): string
     {
-        return $this->productHelperFactory->create()->getProductUrl($product, $this->resourceModel);
+        return $this->productHelperFactory->create()->getProductUrl($product);
     }
 
     /**

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -311,7 +311,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      */
     private function getProductUrl(Product $product): string
     {
-        return $this->productHelperFactory->create()->getProductUrl($product);
+        return $this->productHelperFactory->create()->getProductUrl($product, $this->resourceModel);
     }
 
     /**

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.7.6">
+    <module name="Doofinder_Feed" setup_version="1.7.7">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
Fixes doofinder/support#5082

## Summary
- When a configurable variant (visibility=1) has no canonical URL rewrite for its parent, the fallback route was built with the parent's ID but the **variant's** `url_key` as the slug, producing a mismatched URL
- Fix injects `Magento\Catalog\Model\ResourceModel\Product` and uses `getAttributeRawValue()` to read the parent's `url_key` directly, so the fallback slug is always consistent with the parent product