### PR TITLE
Don't persist Magento generated DI code on the host

### DIFF
--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.7.7">
+    <module name="Doofinder_Feed" setup_version="1.7.8">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       XDEBUG_CONFIG: "client_host=${XDEBUG_HOST} idekey=${XDEBUG_KEY} mode=develop,debug start_with_request=yes"
     volumes:
       - ./app:/app
+      # Don't persist Magento's generated DI code on the host; regenerate it on each up.
+      - /app/generated
       - ./Doofinder:/app/app/code/Doofinder
     ports:
       - "9012:80"


### PR DESCRIPTION
## Summary
- The e2e Magento server bind-mounts `./app:/app`, so `app/generated/code` persists on the host across plugin updates. In developer mode Magento only regenerates a generated class when its file is *missing*, so after a constructor signature change (e.g. `f59b887` shifting `ProductRepository::__construct` params) the stale interceptor calls `parent::__construct()` by position with the wrong types — a fatal `TypeError` that breaks the whole Magento e2e indexation suite.
- Mount an anonymous volume at `/app/generated` so generated DI code is not persisted on the host. The e2e suite brackets every run with `start-service` (`git reset` + `make start`) and `stop-service` (`make stop` == `docker compose down`), so each `up` follows a `down` and gets a fresh, empty `generated/` that Magento regenerates against the just-reset code.
- Verified the two load-bearing facts: `down` + `up` creates a new (not reused) anonymous volume, and that fresh volume comes up empty rather than inheriting the stale host dir masked under the bind mount.
- Context: doofinder/dfcommon#1777. Thanks @juaniten for the suggestion.