### PR TITLE
Fix ownership of the generated DI code volume

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG COMPOSER_VERSION
 
 RUN composer self-update "$COMPOSER_VERSION"
 
-RUN mkdir -p /app
+RUN mkdir -p /app/generated
 
 RUN chown -R application:application /app
 


### PR DESCRIPTION
## Summary
- `docker-compose.yml` mounts an anonymous volume at `/app/generated` so generated DI code is not persisted on the host. Docker creates that volume **root-owned**, because the path does not exist in the image (the Dockerfile only created `/app`), and the mount shadows the host directory that `magento_download` chowns.
- Apache/PHP-FPM runs as uid 1000 (`APACHE_RUN_USER: "#1000"`) and `magento_install` sets `deploy:mode:set developer`, so Magento generates DI classes at request time. It cannot write to a root-owned directory, so every request fails with `Can't create directory /app/generated/code/...` and a fatal `ReflectionException`, returning a 500 in ~0.25s.
- Create `/app/generated` at build time: Docker then initialises the volume with the ownership of the image directory, which the existing `chown -R application:application /app` already sets correctly.

Verified locally — `/app/generated` goes from `root:root` to `1000:1000` and is writable by `application`, and the `Can't create directory` failure is gone.

Note: `make start` does not rebuild, so the e2e Clouding server needs the `web` image rebuilt once for this to take effect.