### PR TITLE
Backfill attributes missing from the product collection

### DIFF
--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -431,7 +431,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                     continue;
                 }
                 $productsMissingAttributesByLink[$linkId] = $product;
-                $missingCodes[$code] = true;
+                $missingCodes[] = $code;
             }
         }
 
@@ -442,7 +442,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $storeId = (int) reset($productsMissingAttributesByLink)->getStoreId();
         $values = $this->fetchRawAttributeValues(
             array_keys($productsMissingAttributesByLink),
-            array_keys($missingCodes),
+            $missingCodes,
             $storeId,
             $linkField
         );

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -25,12 +25,14 @@ use Magento\Framework\Serialize\Serializer\Json;
 use Magento\GroupedProduct\Model\Product\Type\Grouped as GroupedType;
 use Magento\Store\Api\StoreConfigManagerInterface as MagentoStoreConfig;
 use Magento\Store\Model\App\Emulation;
+use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Directory\Model\CurrencyFactory;
 use Doofinder\Feed\Helper\ProductFactory as ProductHelperFactory;
 use Doofinder\Feed\Helper\PriceFactory as PriceHelperFactory;
 use Doofinder\Feed\Helper\InventoryFactory as InventoryHelperFactory;
 use Doofinder\Feed\Helper\StoreConfig;
+use Psr\Log\LoggerInterface;
 
 class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterface
 {
@@ -100,6 +102,9 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     /** @var \Magento\Framework\Serialize\Serializer\Json|null */
     private $serializer;
 
+    /** @var \Psr\Log\LoggerInterface|null */
+    private $logger;
+
     /**
      * ProductRepository constructor.
      *
@@ -121,6 +126,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      * @param ProductRepositoryBase $productRepositoryBase Base product repository.
      * @param int $cacheLimit Product cache size limit (default: 1000).
      * @param Json|null $serializer JSON serializer (optional).
+     * @param LoggerInterface|null $logger Logger (optional).
      */
     public function __construct(
         ImageFactory $imageHelperFactory,
@@ -140,7 +146,8 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         StoreManagerInterface $storeManager,
         ProductRepositoryBase $productRepositoryBase,
         $cacheLimit = 1000,
-        ?Json $serializer = null
+        ?Json $serializer = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->imageHelperFactory = $imageHelperFactory;
         $this->appEmulation = $appEmulation;
@@ -164,6 +171,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         //Add here any custom attributes we want to exclude from indexation
         $this->excludedCustomAttributes = ['special_price', 'special_from_date', 'special_to_date'];
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
+        $this->logger = $logger ?: ObjectManager::getInstance()->get(LoggerInterface::class);
     }
 
     /**
@@ -209,6 +217,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     public function getList(SearchCriteriaInterface $searchCriteria)
     {
         $searchResult = $this->productRepositoryBase->getList($searchCriteria);
+        $this->backfillMissingAttributes($searchResult->getItems());
         $storeId = null;
 
         foreach ($searchResult->getItems() as $product) {
@@ -398,6 +407,109 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $smallImageUrl = $this->getImage($product, 'product_small_image')->getUrl();
         $product->setCustomAttribute('small_image', $smallImageUrl);
         $this->removeExcludedCustomAttributes($product);
+    }
+
+    /**
+     * Fill in the indexable attributes that the product collection did not hydrate
+     *
+     * Products coming from getList() are hydrated by a collection whose attribute load resolves
+     * values through the entity id, while get() reads them through the link field of the loaded
+     * row. On some installations both do not agree and a value present in the database is missing
+     * from the collection item, so it never reaches the feed. Read those values once per page,
+     * keyed by the same link field get() uses, and fill in only the keys that are missing.
+     *
+     * @param ProductInterface[] $products
+     * @return void
+     */
+    private function backfillMissingAttributes(array $products): void
+    {
+        $linkField = $this->resourceModel->getLinkField();
+        $productsByLink = [];
+        $missingCodes = [];
+
+        foreach ($products as $product) {
+            foreach ($this->getIndexableAttributeCodes() as $code) {
+                if (isset($product[$code])) {
+                    continue;
+                }
+                $productsByLink[(int) $product->getData($linkField)] = $product;
+                $missingCodes[$code] = $code;
+            }
+        }
+
+        if (!$productsByLink) {
+            return;
+        }
+
+        $storeId = (int) reset($productsByLink)->getStoreId();
+        $values = $this->fetchRawAttributeValues(array_keys($productsByLink), $missingCodes, $storeId, $linkField);
+        $backfilled = [];
+
+        foreach ($values as $linkId => $attributeValues) {
+            $product = $productsByLink[$linkId];
+            foreach ($attributeValues as $code => $value) {
+                if (isset($product[$code]) || $value === null || $value === '') {
+                    continue;
+                }
+                $product->setData($code, $value);
+                $backfilled[$code] = $code;
+            }
+        }
+
+        if ($backfilled) {
+            $this->logger->warning(
+                'Doofinder: indexable attributes missing from the product collection',
+                [
+                    'store_id' => $storeId,
+                    'link_field' => $linkField,
+                    'products' => count($values),
+                    'attributes' => array_values($backfilled),
+                ]
+            );
+        }
+    }
+
+    /**
+     * Read attribute values straight from the EAV tables, one query per backend table
+     *
+     * Values are ordered by store id so that a store scoped value overwrites the default one,
+     * which is how the product model resolves them when it is loaded by get().
+     *
+     * @param int[] $linkIds
+     * @param string[] $codes
+     * @param int $storeId
+     * @param string $linkField
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchRawAttributeValues(array $linkIds, array $codes, int $storeId, string $linkField): array
+    {
+        $attributesByTable = [];
+
+        foreach ($codes as $code) {
+            $attribute = $this->resourceModel->getAttribute($code);
+            if (!$attribute || !$attribute->getId() || $attribute->getBackend()->isStatic()) {
+                continue;
+            }
+            $attributesByTable[$attribute->getBackend()->getTable()][(int) $attribute->getId()] = $code;
+        }
+
+        $connection = $this->resourceModel->getConnection();
+        $values = [];
+
+        foreach ($attributesByTable as $table => $attributes) {
+            $select = $connection->select()
+                ->from(['v' => $table], [$linkField, 'attribute_id', 'value'])
+                ->where("v.$linkField IN (?)", $linkIds)
+                ->where('v.attribute_id IN (?)', array_keys($attributes))
+                ->where('v.store_id IN (?)', [Store::DEFAULT_STORE_ID, $storeId])
+                ->order('v.store_id ASC');
+
+            foreach ($connection->fetchAll($select) as $row) {
+                $values[(int) $row[$linkField]][$attributes[(int) $row['attribute_id']]] = $row['value'];
+            }
+        }
+
+        return $values;
     }
 
     /**

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -447,9 +447,8 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             $linkField
         );
 
-        foreach ($values as $linkId => $attributeValues) {
-            $product = $productsMissingAttributesByLink[$linkId];
-            foreach ($attributeValues as $code => $value) {
+        foreach ($productsMissingAttributesByLink as $linkId => $product) {
+            foreach ($values[$linkId] ?? [] as $code => $value) {
                 if (isset($product[$code]) || $value === null || $value === '') {
                     continue;
                 }

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -428,11 +428,16 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $missingCodes = [];
 
         foreach ($products as $product) {
+            $linkId = $this->getLinkId($product, $linkField);
+            if (!$linkId) {
+                continue;
+            }
+
             foreach ($this->getIndexableAttributeCodes() as $code) {
                 if (isset($product[$code])) {
                     continue;
                 }
-                $productsByLink[(int) $product->getData($linkField)] = $product;
+                $productsByLink[$linkId] = $product;
                 $missingCodes[$code] = $code;
             }
         }
@@ -467,6 +472,29 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                 ]
             );
         }
+    }
+
+    /**
+     * Resolve the row the attribute values of a product hang from
+     *
+     * The collection selects the whole entity table, so items carry the link field. When they do
+     * not, the entity id is only a valid substitute where both are the same column: on an
+     * installation where they differ, a row id taken from an entity id points at another product's
+     * row, so the product is left alone instead.
+     *
+     * @param ProductInterface $product
+     * @param string $linkField
+     * @return int
+     */
+    private function getLinkId($product, string $linkField): int
+    {
+        $linkId = (int) $product->getData($linkField);
+
+        if (!$linkId && $linkField === $this->resourceModel->getEntityIdField()) {
+            $linkId = (int) $product->getId();
+        }
+
+        return $linkId;
     }
 
     /**

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -418,7 +418,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     {
         $linkField = $this->resourceModel->getLinkField();
         $productsMissingAttributesByLink = [];
-        $missingCodes = [];
+        $missingAttributeCodes = [];
 
         foreach ($products as $product) {
             $linkId = $this->getLinkId($product, $linkField);
@@ -431,7 +431,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                     continue;
                 }
                 $productsMissingAttributesByLink[$linkId] = $product;
-                $missingCodes[] = $code;
+                $missingAttributeCodes[] = $code;
             }
         }
 
@@ -442,7 +442,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $storeId = (int) reset($productsMissingAttributesByLink)->getStoreId();
         $values = $this->fetchRawAttributeValues(
             array_keys($productsMissingAttributesByLink),
-            $missingCodes,
+            $missingAttributeCodes,
             $storeId,
             $linkField
         );

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -431,7 +431,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                     continue;
                 }
                 $productsMissingAttributesByLink[$linkId] = $product;
-                $missingCodes[$code] = $code;
+                $missingCodes[$code] = true;
             }
         }
 
@@ -442,7 +442,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $storeId = (int) reset($productsMissingAttributesByLink)->getStoreId();
         $values = $this->fetchRawAttributeValues(
             array_keys($productsMissingAttributesByLink),
-            $missingCodes,
+            array_keys($missingCodes),
             $storeId,
             $linkField
         );

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -417,7 +417,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     private function backfillMissingAttributes(array $products): void
     {
         $linkField = $this->resourceModel->getLinkField();
-        $productsByLink = [];
+        $productsMissingAttributesByLink = [];
         $missingCodes = [];
 
         foreach ($products as $product) {
@@ -430,20 +430,25 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                 if (isset($product[$code])) {
                     continue;
                 }
-                $productsByLink[$linkId] = $product;
+                $productsMissingAttributesByLink[$linkId] = $product;
                 $missingCodes[$code] = $code;
             }
         }
 
-        if (!$productsByLink) {
+        if (!$productsMissingAttributesByLink) {
             return;
         }
 
-        $storeId = (int) reset($productsByLink)->getStoreId();
-        $values = $this->fetchRawAttributeValues(array_keys($productsByLink), $missingCodes, $storeId, $linkField);
+        $storeId = (int) reset($productsMissingAttributesByLink)->getStoreId();
+        $values = $this->fetchRawAttributeValues(
+            array_keys($productsMissingAttributesByLink),
+            $missingCodes,
+            $storeId,
+            $linkField
+        );
 
         foreach ($values as $linkId => $attributeValues) {
-            $product = $productsByLink[$linkId];
+            $product = $productsMissingAttributesByLink[$linkId];
             foreach ($attributeValues as $code => $value) {
                 if (isset($product[$code]) || $value === null || $value === '') {
                     continue;

--- a/Doofinder/Feed/Model/ProductRepository.php
+++ b/Doofinder/Feed/Model/ProductRepository.php
@@ -32,7 +32,6 @@ use Doofinder\Feed\Helper\ProductFactory as ProductHelperFactory;
 use Doofinder\Feed\Helper\PriceFactory as PriceHelperFactory;
 use Doofinder\Feed\Helper\InventoryFactory as InventoryHelperFactory;
 use Doofinder\Feed\Helper\StoreConfig;
-use Psr\Log\LoggerInterface;
 
 class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterface
 {
@@ -102,9 +101,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     /** @var \Magento\Framework\Serialize\Serializer\Json|null */
     private $serializer;
 
-    /** @var \Psr\Log\LoggerInterface|null */
-    private $logger;
-
     /**
      * ProductRepository constructor.
      *
@@ -126,7 +122,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      * @param ProductRepositoryBase $productRepositoryBase Base product repository.
      * @param int $cacheLimit Product cache size limit (default: 1000).
      * @param Json|null $serializer JSON serializer (optional).
-     * @param LoggerInterface|null $logger Logger (optional).
      */
     public function __construct(
         ImageFactory $imageHelperFactory,
@@ -146,8 +141,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         StoreManagerInterface $storeManager,
         ProductRepositoryBase $productRepositoryBase,
         $cacheLimit = 1000,
-        ?Json $serializer = null,
-        ?LoggerInterface $logger = null
+        ?Json $serializer = null
     ) {
         $this->imageHelperFactory = $imageHelperFactory;
         $this->appEmulation = $appEmulation;
@@ -171,7 +165,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         //Add here any custom attributes we want to exclude from indexation
         $this->excludedCustomAttributes = ['special_price', 'special_from_date', 'special_to_date'];
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
-        $this->logger = $logger ?: ObjectManager::getInstance()->get(LoggerInterface::class);
     }
 
     /**
@@ -448,7 +441,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
 
         $storeId = (int) reset($productsByLink)->getStoreId();
         $values = $this->fetchRawAttributeValues(array_keys($productsByLink), $missingCodes, $storeId, $linkField);
-        $backfilled = [];
 
         foreach ($values as $linkId => $attributeValues) {
             $product = $productsByLink[$linkId];
@@ -457,20 +449,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                     continue;
                 }
                 $product->setData($code, $value);
-                $backfilled[$code] = $code;
             }
-        }
-
-        if ($backfilled) {
-            $this->logger->warning(
-                'Doofinder: indexable attributes missing from the product collection',
-                [
-                    'store_id' => $storeId,
-                    'link_field' => $linkField,
-                    'products' => count($values),
-                    'attributes' => array_values($backfilled),
-                ]
-            );
         }
     }
 

--- a/Doofinder/Feed/composer.json
+++ b/Doofinder/Feed/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {

--- a/Doofinder/Feed/etc/module.xml
+++ b/Doofinder/Feed/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Doofinder_Feed" setup_version="1.8.0">
+    <module name="Doofinder_Feed" setup_version="1.8.1">
         <sequence>
             <module name="Magento_Integration" />
         </sequence>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder/doofinder-magento2",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Doofinder module for Magento 2",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
## Summary
Alternative to https://github.com/doofinder/doofinder-magento2/pull/492. There, a new query was added and launched for every product and attribute. 

This PR wants to reduce the number of queries, by obtaining all the products and their links with the EAV tables (this changes between Open Source and Adobe Commerce Magento versions), and launching a single query for each page.